### PR TITLE
Fix #19, OnCreate/OnMatch without identifier

### DIFF
--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -172,14 +172,14 @@ namespace Neo4jClient.Cypher
             return Mutate(w => w.AppendClause("MERGE " + mergeText));
         }
 
-        public ICypherFluentQuery OnCreate(string identity)
+        public ICypherFluentQuery OnCreate()
         {
-            return Mutate(w => w.AppendClause("ON CREATE " + identity));
+            return Mutate(w => w.AppendClause("ON CREATE"));
         }
 
-        public ICypherFluentQuery OnMatch(string identity)
+        public ICypherFluentQuery OnMatch()
         {
-            return Mutate(w => w.AppendClause("ON MATCH " + identity));
+            return Mutate(w => w.AppendClause("ON MATCH"));
         }
 
         public ICypherFluentQuery CreateUnique(string createUniqueText)

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -31,8 +31,8 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery Match(params string[] matchText);
         ICypherFluentQuery OptionalMatch(string pattern);
         ICypherFluentQuery Merge(string mergeText);
-        ICypherFluentQuery OnCreate(string identity);
-        ICypherFluentQuery OnMatch(string identity);
+        ICypherFluentQuery OnCreate();
+        ICypherFluentQuery OnMatch();
         ICypherFluentQuery CreateUnique(string createUniqueText);
         ICypherFluentQuery Create(string createText);
         [Obsolete("Use Create(string) with explicitly named params instead. For example, instead of Create(\"(c:Customer {0})\", customer), use Create(\"(c:Customer {customer})\").WithParams(new { customer }).")]

--- a/Test/Cypher/CypherFluentQueryMergeTests.cs
+++ b/Test/Cypher/CypherFluentQueryMergeTests.cs
@@ -28,12 +28,12 @@ namespace Neo4jClient.Test.Cypher
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
                 .Merge("(robert:Person)")
-                .OnCreate("robert")
+                .OnCreate()
                 .Set("robert.Created = timestamp()")
                 .Query;
 
             // Assert
-            Assert.AreEqual("MERGE (robert:Person)\r\nON CREATE robert\r\nSET robert.Created = timestamp()", query.QueryText);
+            Assert.AreEqual("MERGE (robert:Person)\r\nON CREATE\r\nSET robert.Created = timestamp()", query.QueryText);
         }
 
         [Test]
@@ -43,12 +43,12 @@ namespace Neo4jClient.Test.Cypher
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
                 .Merge("(robert:Person)")
-                .OnMatch("robert")
+                .OnMatch()
                 .Set("robert.LastSeen = timestamp()")
                 .Query;
 
             // Assert
-            Assert.AreEqual("MERGE (robert:Person)\r\nON MATCH robert\r\nSET robert.LastSeen = timestamp()", query.QueryText);
+            Assert.AreEqual("MERGE (robert:Person)\r\nON MATCH\r\nSET robert.LastSeen = timestamp()", query.QueryText);
         }
 
         [Test]
@@ -58,14 +58,14 @@ namespace Neo4jClient.Test.Cypher
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
                 .Merge("(robert:Person)")
-                .OnCreate("robert")
+                .OnCreate()
                 .Set("robert.Created = timestamp()")
-                .OnMatch("robert")
+                .OnMatch()
                 .Set("robert.LastSeen = timestamp()")
                 .Query;
 
             // Assert
-            Assert.AreEqual("MERGE (robert:Person)\r\nON CREATE robert\r\nSET robert.Created = timestamp()\r\nON MATCH robert\r\nSET robert.LastSeen = timestamp()", query.QueryText);
+            Assert.AreEqual("MERGE (robert:Person)\r\nON CREATE\r\nSET robert.Created = timestamp()\r\nON MATCH\r\nSET robert.LastSeen = timestamp()", query.QueryText);
         }
     }
 }


### PR DESCRIPTION
In version 2.0.0-RC1, specifying an identifier when ON CREATE/ON MATCH
is not permitted.
