### PR TITLE
added support for Cypher REMOVE

### DIFF
--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -265,6 +265,12 @@ namespace Neo4jClient.Cypher
                 w.AppendClause(string.Format("SET {0}", setText)));
         }
 
+        public ICypherFluentQuery Remove(string removeText)
+        {
+            return Mutate(w =>
+                w.AppendClause(string.Format("REMOVE {0}", removeText)));
+        }
+
         public ICypherFluentQuery ForEach(string text)
         {
             return Mutate(w => w.AppendClause("FOREACH " + text));

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -42,6 +42,7 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery Delete(string identities);
         ICypherFluentQuery Drop(string dropText);
         ICypherFluentQuery Set(string setText);
+        ICypherFluentQuery Remove(string removeText);
         ICypherFluentQuery ForEach(string text);
         ICypherFluentQuery Union();
         ICypherFluentQuery UnionAll();

--- a/Test/Cypher/CypherFluentQueryRemoveTests.cs
+++ b/Test/Cypher/CypherFluentQueryRemoveTests.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using NSubstitute;
+using Neo4jClient.Cypher;
+using System;
+
+namespace Neo4jClient.Test.Cypher
+{
+    [TestFixture]
+    public class CypherFluentQueryRemoveTests
+    {
+        [Test]
+        public void RemoveProperty()
+        {
+            // Arrange
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .Start("n", (NodeReference)3)
+                .Remove("n.age")
+                .Return<Node<Object>>("n")
+                .Query;
+
+            // Assert
+            Assert.AreEqual("START n=node({p0})\r\nREMOVE n.age\r\nRETURN n", query.QueryText);
+            Assert.AreEqual(3, query.QueryParameters["p0"]);
+        }
+
+        [Test]
+        public void RemoveLabel()
+        {
+            // Arrange
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .Start("n", (NodeReference)3)
+                .Remove("n:Person")
+                .Return<Node<Object>>("n")
+                .Query;
+
+            // Assert
+            Assert.AreEqual("START n=node({p0})\r\nREMOVE n:Person\r\nRETURN n", query.QueryText);
+            Assert.AreEqual(3, query.QueryParameters["p0"]);
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Cypher\CypherFluentQueryParserVersionTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryMergeTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryMatchTests.cs" />
+    <Compile Include="Cypher\CypherFluentQueryRemoveTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryWithParamTests.cs" />
     <Compile Include="Cypher\DocumentationExamples.cs" />
     <Compile Include="Cypher\UnionTests.cs" />


### PR DESCRIPTION
I've added support for the Cypher REMOVE keyword. It can either remove a property or a label from a node; these cases are covered in the unit tests.
