### PR TITLE
Overloaded the Unwind operator to accept a generic collection. 

### DIFF
--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -285,6 +285,11 @@ namespace Neo4jClient.Cypher
             return Mutate(w => w.AppendClause(string.Format("UNWIND {0} AS {1}", collectionName, columnName)));
         }
 
+        public ICypherFluentQuery Unwind<TType>(IEnumerable<TType> collection, string alias)
+        {
+            return Mutate(w => w.AppendClause(string.Format("UNWIND {{{0}}} AS {1}", alias, alias)).CreateParameter(alias, collection));
+        }
+
         public ICypherFluentQuery Union()
         {
             return Mutate(w => w.AppendClause("UNION"));

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -45,6 +45,7 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery Remove(string removeText);
         ICypherFluentQuery ForEach(string text);
         ICypherFluentQuery Unwind(string collection, string columnName);
+        ICypherFluentQuery Unwind<TType>(IEnumerable<TType> collection, string alias);        
         ICypherFluentQuery Union();
         ICypherFluentQuery UnionAll();
         ICypherFluentQuery Limit(int? limit);

--- a/Test/Cypher/CypherFluentQueryUnwindTests.cs
+++ b/Test/Cypher/CypherFluentQueryUnwindTests.cs
@@ -32,5 +32,19 @@ namespace Neo4jClient.Test.Cypher
 
             Assert.AreEqual("WITH collection\r\nUNWIND collection AS column", query.QueryText);
         }
+
+        [Test]
+        public void TestUnwindUsingCollection()
+        {
+            var collection = new int[] { 1, 2, 3 };
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .Unwind(collection, "alias")
+                .Query;
+
+            Assert.AreEqual("UNWIND {alias} AS alias", query.QueryText);
+            Assert.AreEqual(1, query.QueryParameters.Count);
+            Assert.AreEqual(collection, query.QueryParameters["alias"]);
+        }
     }
 }


### PR DESCRIPTION
This will support the "Create nodes from a collection parameter" section (9.6) of the Neo4j manual. Allows creating or retrieving multiple nodes and relationships from a parameter-list in a single query without using FOREACH.
