### PR TITLE
Issue 75 - Add MaxExecutionTime to the CypherFluentQuery

### DIFF
--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -366,6 +366,12 @@ namespace Neo4jClient.Cypher
             return ParserVersion(new Version(major, minor));
         }
 
+        public ICypherFluentQuery MaxExecutionTime(int milliseconds)
+        {
+            QueryWriter.MaxExecutionTime = milliseconds;
+            return this;
+        }
+
         public static string ApplyCamelCase(bool isCamelCase, string propertyName)
         {
             return isCamelCase

--- a/Neo4jClient/Cypher/CypherQuery.cs
+++ b/Neo4jClient/Cypher/CypherQuery.cs
@@ -13,17 +13,20 @@ namespace Neo4jClient.Cypher
         readonly IDictionary<string, object> queryParameters;
         readonly CypherResultMode resultMode;
         readonly IContractResolver jsonContractResolver;
+        readonly int? maxExecutionTime;
 
         public CypherQuery(
             string queryText,
             IDictionary<string, object> queryParameters,
             CypherResultMode resultMode, 
-            IContractResolver contractResolver = null)
+            IContractResolver contractResolver = null,
+            int? maxExecutionTime = null)
         {
             this.queryText = queryText;
             this.queryParameters = queryParameters;
             this.resultMode = resultMode;
             jsonContractResolver = contractResolver ?? GraphClient.DefaultJsonContractResolver;
+            this.maxExecutionTime = maxExecutionTime;
         }
 
         public IDictionary<string, object> QueryParameters
@@ -44,6 +47,11 @@ namespace Neo4jClient.Cypher
         public IContractResolver JsonContractResolver
         {
             get { return jsonContractResolver; }
+        }
+
+        public int? MaxExecutionTime
+        {
+            get { return maxExecutionTime; }
         }
 
         CustomJsonSerializer BuildSerializer()

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -17,6 +17,8 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery ParserVersion(Version version);
         ICypherFluentQuery ParserVersion(int major, int minor);
 
+        ICypherFluentQuery MaxExecutionTime(int milliseconds);
+
         ICypherFluentQuery Start(object startBits);
         ICypherFluentQuery Start(IDictionary<string, object> startBits);
         [Obsolete("Use Start(new { identity = startText }) instead. See https://bitbucket.org/Readify/neo4jclient/issue/74/support-nicer-cypher-start-notation for more details about this change.")]

--- a/Neo4jClient/Cypher/QueryWriter.cs
+++ b/Neo4jClient/Cypher/QueryWriter.cs
@@ -35,11 +35,13 @@ namespace Neo4jClient.Cypher
             set { resultMode = value; }
         }
 
+        public int? MaxExecutionTime { get; set; }
+
         public QueryWriter Clone()
         {
             var clonedQueryTextBuilder = new StringBuilder(queryTextBuilder.ToString());
             var clonedParameters = new Dictionary<string, object>(queryParameters);
-            return new QueryWriter(clonedQueryTextBuilder, clonedParameters, resultMode);
+            return new QueryWriter(clonedQueryTextBuilder, clonedParameters, resultMode){MaxExecutionTime = this.MaxExecutionTime};
         }
 
         public CypherQuery ToCypherQuery(IContractResolver contractResolver = null)
@@ -52,7 +54,8 @@ namespace Neo4jClient.Cypher
                 queryText,
                 new Dictionary<string, object>(queryParameters),
                 resultMode, 
-                contractResolver);
+                contractResolver,
+                MaxExecutionTime);
         }
 
         public string CreateParameter(object paramValue)

--- a/Test/Cypher/CypherFluentQueryMaxExecutionTimeTests.cs
+++ b/Test/Cypher/CypherFluentQueryMaxExecutionTimeTests.cs
@@ -1,0 +1,36 @@
+﻿using NSubstitute;
+using NUnit.Framework;
+using Neo4jClient.Cypher;
+
+namespace Neo4jClient.Test.Cypher
+{
+    public class CypherFluentQueryMaxExecutionTimeTests
+    {
+        [Test]
+        public void SetsMaxExecutionTime_WhenUsingAReturnTypeQuery()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .MaxExecutionTime(100)
+                .Match("n")
+                .Return<object>("n")
+                .Query;
+
+            Assert.AreEqual(100, query.MaxExecutionTime);
+        }
+
+        [Test]
+        public void SetsMaxExecutionTime_WhenUsingANonReturnTypeQuery()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .MaxExecutionTime(100)
+                .Match("n")
+                .Set("n.Value = 'value'")
+                .Query;
+
+            Assert.AreEqual(100, query.MaxExecutionTime);
+        }
+
+    }
+}

--- a/Test/GraphClientTests/Cypher/ExecuteCypherTests.cs
+++ b/Test/GraphClientTests/Cypher/ExecuteCypherTests.cs
@@ -1,11 +1,18 @@
 ﻿using System.Collections.Generic;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
 using System.Net;
+using NSubstitute;
 using NUnit.Framework;
 using Neo4jClient.ApiModels.Cypher;
 using Neo4jClient.Cypher;
 
 namespace Neo4jClient.Test.GraphClientTests.Cypher
 {
+
+
     [TestFixture]
     public class ExecuteCypherTests
     {
@@ -35,6 +42,74 @@ namespace Neo4jClient.Test.GraphClientTests.Cypher
 
                 //Act
                 graphClient.ExecuteCypher(cypherQuery);
+            }
+        }
+
+        [Test]
+        public void SendsCommandWithCorrectTimeout()
+        {
+            const string queryText = "MATCH n SET n.Value = 'value'";
+            const int expectedMaxExecutionTime = 100;
+
+            var cypherQuery = new CypherQuery(queryText, new Dictionary<string, object>(), CypherResultMode.Set, maxExecutionTime: expectedMaxExecutionTime);
+            var cypherApiQuery = new CypherApiQuery(cypherQuery);
+
+            using (var testHarness = new RestTestHarness
+            {
+                {
+                    MockRequest.Get(""),
+                    MockResponse.NeoRoot()
+                },
+                {
+                    MockRequest.PostObjectAsJson("/cypher", cypherApiQuery),
+                    MockResponse.Http((int) HttpStatusCode.OK)
+                }
+            })
+            {
+                var httpClient = testHarness.GenerateHttpClient(testHarness.BaseUri);
+                var graphClient = new GraphClient(new Uri(testHarness.BaseUri), httpClient);
+                graphClient.Connect();
+
+                httpClient.ClearReceivedCalls();
+                ((IRawGraphClient)graphClient).ExecuteCypher(cypherQuery);
+
+                var call = httpClient.ReceivedCalls().Single();
+                var requestMessage = (HttpRequestMessage)call.GetArguments()[0];
+                var maxExecutionTimeHeader = requestMessage.Headers.Single(h => h.Key == "max-execution-time");
+                Assert.AreEqual(expectedMaxExecutionTime.ToString(CultureInfo.InvariantCulture), maxExecutionTimeHeader.Value.Single());
+            }
+        }
+
+        [Test]
+        public void DoesntSetMaxExecutionTime_WhenNotSet()
+        {
+            const string queryText = "MATCH n SET n.Value = 'value'";
+
+            var cypherQuery = new CypherQuery(queryText, new Dictionary<string, object>(), CypherResultMode.Set);
+            var cypherApiQuery = new CypherApiQuery(cypherQuery);
+
+            using (var testHarness = new RestTestHarness
+            {
+                {
+                    MockRequest.Get(""),
+                    MockResponse.NeoRoot()
+                },
+                {
+                    MockRequest.PostObjectAsJson("/cypher", cypherApiQuery),
+                    MockResponse.Http((int) HttpStatusCode.OK)
+                }
+            })
+            {
+                var httpClient = testHarness.GenerateHttpClient(testHarness.BaseUri);
+                var graphClient = new GraphClient(new Uri(testHarness.BaseUri), httpClient);
+                graphClient.Connect();
+
+                httpClient.ClearReceivedCalls();
+                ((IRawGraphClient)graphClient).ExecuteCypher(cypherQuery);
+
+                var call = httpClient.ReceivedCalls().Single();
+                var requestMessage = (HttpRequestMessage)call.GetArguments()[0];
+                Assert.IsFalse(requestMessage.Headers.Any(h => h.Key == "max-execution-time"));
             }
         }
     }

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Cypher\CypherFluentQueryDropTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryConstraintTest.cs" />
     <Compile Include="Cypher\CypherFluentQueryParserVersionTests.cs" />
+    <Compile Include="Cypher\CypherFluentQueryMaxExecutionTimeTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryMergeTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryMatchTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryRemoveTests.cs" />


### PR DESCRIPTION
Gives the ability to run:

    client.Cypher.MaxExecutionTime(1000).Match(/*ETC*/);

and have the query time out on the Neo4j server on a query-by-query basis.