### PR TITLE
Adds the ability for a user to pass free text to the ParserVersion call

### DIFF
--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -353,12 +353,17 @@ namespace Neo4jClient.Cypher
             get { return Client; }
         }
 
+        public ICypherFluentQuery ParserVersion(string version)
+        {
+            return Mutate(w => w.AppendClause(string.Format("CYPHER {0}", version)));
+        }
+
         public ICypherFluentQuery ParserVersion(Version version)
         {
             if (version < minimumCypherParserVersion)
-                return Mutate(w => w.AppendClause("CYPHER LEGACY"));
+                return ParserVersion("LEGACY");
             
-            return Mutate(w => w.AppendClause(string.Format("CYPHER {0}.{1}", version.Major, version.Minor)));
+            return ParserVersion(string.Format("{0}.{1}", version.Major, version.Minor));
         }
 
         public ICypherFluentQuery ParserVersion(int major, int minor)

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -14,6 +14,7 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery WithParams(IDictionary<string,object> parameters);
         ICypherFluentQuery WithParams(object parameters);
 
+        ICypherFluentQuery ParserVersion(string version);
         ICypherFluentQuery ParserVersion(Version version);
         ICypherFluentQuery ParserVersion(int major, int minor);
 

--- a/Test/Cypher/CypherFluentQueryParserVersionTests.cs
+++ b/Test/Cypher/CypherFluentQueryParserVersionTests.cs
@@ -8,6 +8,23 @@ namespace Neo4jClient.Test.Cypher
     public class CypherFluentQueryParserVersionTests
     {
         [Test]
+        public void SetsVersionToFreeTextGiven()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .ParserVersion("2.1.experimental")
+                .Start(new
+                {
+                    n = All.Nodes,
+                })
+                .Return<object>("n")
+                .Query;
+
+            Assert.AreEqual("CYPHER 2.1.experimental\r\nSTART n=node(*)\r\nRETURN n", query.QueryText);
+            Assert.AreEqual(0, query.QueryParameters.Count);   
+        }
+
+        [Test]
         public void SetsVersion_WhenUsingVersionOverload()
         {
             var client = Substitute.For<IRawGraphClient>();


### PR DESCRIPTION
Giving the ability to use things like `2.1.experimental`, fixes issue #73

    client.ParserVersion("2.1.experimental").Match(/*etc*/);

results in:

    CYPHER 2.1.experimental 
    MATCH /*etc*/
    