### PR TITLE
Checks that the version supports the UNWIND operator

### DIFF
--- a/Neo4jClient/Cypher/CypherCapabilities.cs
+++ b/Neo4jClient/Cypher/CypherCapabilities.cs
@@ -2,21 +2,31 @@ namespace Neo4jClient.Cypher
 {
     public class CypherCapabilities
     {
-        public readonly static CypherCapabilities Cypher19 = new CypherCapabilities
+        public readonly static CypherCapabilities Cypher190 = new CypherCapabilities
         {
             SupportsPropertySuffixesForControllingNullComparisons = true,
-            SupportsNullComparisonsWithIsOperator = true
+            SupportsNullComparisonsWithIsOperator = true,
+            SupportsUnwindOperator = false
         };
 
-        public readonly static CypherCapabilities Cypher20 = new CypherCapabilities
+        public readonly static CypherCapabilities Cypher203 = new CypherCapabilities
         {
             SupportsPropertySuffixesForControllingNullComparisons = false,
-            SupportsNullComparisonsWithIsOperator = false
+            SupportsNullComparisonsWithIsOperator = false,
+            SupportsUnwindOperator = false
         };
 
-        public static readonly CypherCapabilities Default = Cypher20;
+        public static readonly CypherCapabilities Cypher204 = new CypherCapabilities
+        {
+            SupportsPropertySuffixesForControllingNullComparisons = false,
+            SupportsNullComparisonsWithIsOperator = false,
+            SupportsUnwindOperator = true
+        };
+
+        public static readonly CypherCapabilities Default = Cypher204;
 
         public bool SupportsPropertySuffixesForControllingNullComparisons { get; set; }
         public bool SupportsNullComparisonsWithIsOperator { get; set; }
+        public bool SupportsUnwindOperator { get; set; }
     }
 }

--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -293,13 +293,27 @@ namespace Neo4jClient.Cypher
             return Mutate(w => w.AppendClause("FOREACH " + text));
         }
 
+        protected void CheckForUnwindCapabilities()
+        {
+            CypherCapabilities capabilities = Client.CypherCapabilities ?? CypherCapabilities.Default;
+
+            if (!capabilities.SupportsUnwindOperator)
+            {
+                throw new NotSupportedException("The UNWIND operator is only supported from version 2.0.4 onwards.");
+            }
+        }
+
         public ICypherFluentQuery Unwind(string collectionName, string identity)
         {
+            CheckForUnwindCapabilities();
+
             return Mutate(w => w.AppendClause(string.Format("UNWIND {0} AS {1}", collectionName, identity)));
         }
 
         public ICypherFluentQuery Unwind(IEnumerable collection, string identity)
         {
+            CheckForUnwindCapabilities();
+
             return Mutate(w => w.AppendClause("UNWIND {0} AS " + identity, collection));
         }
 

--- a/Neo4jClient/Cypher/CypherFluentQuery`TResult.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`TResult.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
@@ -15,7 +17,16 @@ namespace Neo4jClient.Cypher
 
         public new ICypherFluentQuery<TResult> Unwind(string collectionName, string columnName)
         {
+            CheckForUnwindCapabilities();
+
             return Mutate<TResult>(w => w.AppendClause(string.Format("UNWIND {0} AS {1}", collectionName, columnName)));
+        }
+
+        public new ICypherFluentQuery<TResult> Unwind(IEnumerable collection, string identity)
+        {
+            CheckForUnwindCapabilities();
+
+            return Mutate<TResult>(w => w.AppendClause("UNWIND {0} AS " + identity, collection));
         }
 
         public new ICypherFluentQuery<TResult> Limit(int? limit)

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -229,7 +229,13 @@ namespace Neo4jClient
             jsonStreamingAvailable = RootApiResponse.Version >= new Version(1, 8);
 
             if (RootApiResponse.Version < new Version(2, 0))
-                cypherCapabilities = CypherCapabilities.Cypher19;
+            {
+                cypherCapabilities = CypherCapabilities.Cypher190;
+            }
+            else if (RootApiResponse.Version < new Version(2, 0, 4))
+            {
+                cypherCapabilities = CypherCapabilities.Cypher203;
+            }
 
             stopwatch.Stop();
             OnOperationCompleted(new OperationCompletedEventArgs

--- a/Test/Cypher/CypherFluentQueryUnwindTests.cs
+++ b/Test/Cypher/CypherFluentQueryUnwindTests.cs
@@ -1,4 +1,5 @@
-﻿using Neo4jClient.Cypher;
+﻿using System;
+using Neo4jClient.Cypher;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -10,6 +11,27 @@ namespace Neo4jClient.Test.Cypher
     [TestFixture]
     public class CypherFluentQueryUnwindTests
     {
+        [Test]
+        public void CheckThatUnwindIsNotSupportedFor203()
+        {
+            using (var testHarness = new RestTestHarness
+            {
+                {
+                    MockRequest.Get(""),
+                    MockResponse.NeoRoot20()
+                }
+            })
+            {
+                var client = testHarness.CreateAndConnectGraphClient();
+
+                Assert.Throws<NotSupportedException>(() =>
+                {
+                    var query = new CypherFluentQuery(client)
+                        .Unwind("a", "b");
+                });
+            }
+        }
+
         [Test]
         public void TestUnwindConstruction()
         {

--- a/Test/Cypher/CypherReturnExpressionBuilderTests.cs
+++ b/Test/Cypher/CypherReturnExpressionBuilderTests.cs
@@ -128,7 +128,7 @@ namespace Neo4jClient.Test.Cypher
                     NumberOfCats = n.As<Foo>().NumberOfCats
                 };
 
-            var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, CypherCapabilities.Cypher19, GraphClient.DefaultJsonConverters);
+            var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, CypherCapabilities.Cypher190, GraphClient.DefaultJsonConverters);
 
             Assert.AreEqual("n.Age AS Age, n.NumberOfCats? AS NumberOfCats", returnExpression.Text);
         }

--- a/Test/Cypher/CypherWhereExpressionBuilderTests.cs
+++ b/Test/Cypher/CypherWhereExpressionBuilderTests.cs
@@ -88,7 +88,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == 123;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! = {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -100,7 +100,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != 123;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar? <> {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -113,7 +113,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar > 123;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! > {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -126,7 +126,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar >= 123;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! >= {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -139,7 +139,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar < 123;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! < {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -152,7 +152,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar <= 123;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! <= {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -168,7 +168,7 @@ namespace Neo4jClient.Test.Cypher
             };
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == fooWithNulls.NullableBar;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar? is null)", result);
         }
@@ -183,7 +183,7 @@ namespace Neo4jClient.Test.Cypher
             };
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == fooWithNulls.NullableBar;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher20);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher203);
 
             Assert.AreEqual("(not(has(foo.NullableBar)))", result);
         }
@@ -198,7 +198,7 @@ namespace Neo4jClient.Test.Cypher
             };
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != fooWithNulls.NullableBar;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar? is not null)", result);
         }
@@ -213,7 +213,7 @@ namespace Neo4jClient.Test.Cypher
             };
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != fooWithNulls.NullableBar;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher20);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher203);
 
             Assert.AreEqual("(has(foo.NullableBar))", result);
         }
@@ -224,7 +224,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == null;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar? is null)", result);
         }
@@ -235,7 +235,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != null;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar? is not null)", result);
         }
@@ -248,7 +248,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == localObject.NoneCypherLocalProperty;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! = {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -262,7 +262,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != localObject.NoneCypherLocalProperty;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar? <> {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -276,7 +276,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar > localObject.NoneCypherLocalProperty;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! > {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -290,7 +290,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar >= localObject.NoneCypherLocalProperty;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! >= {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -304,7 +304,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar < localObject.NoneCypherLocalProperty;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! < {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);
@@ -318,7 +318,7 @@ namespace Neo4jClient.Test.Cypher
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar <= localObject.NoneCypherLocalProperty;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher190);
 
             Assert.AreEqual("(foo.NullableBar! <= {p0})", result);
             Assert.AreEqual(123, parameters["p0"]);

--- a/Test/GraphClientTests/ConnectTests.cs
+++ b/Test/GraphClientTests/ConnectTests.cs
@@ -108,7 +108,23 @@ namespace Neo4jClient.Test.GraphClientTests
             using (var testHarness = new RestTestHarness())
             {
                 var graphClient = testHarness.CreateAndConnectGraphClient();
-                Assert.AreEqual(CypherCapabilities.Cypher19, graphClient.CypherCapabilities);
+                Assert.AreEqual(CypherCapabilities.Cypher190, graphClient.CypherCapabilities);
+            }
+        }
+
+        [Test]
+        public void ShouldReturnCypher204Capabilities()
+        {
+            using (var testHarness = new RestTestHarness
+            {
+                {
+                    MockRequest.Get(""),
+                    MockResponse.NeoRoot204()
+                }
+            })
+            {
+                var graphClient = testHarness.CreateAndConnectGraphClient();
+                Assert.AreEqual(CypherCapabilities.Cypher204, graphClient.CypherCapabilities);
             }
         }
 
@@ -124,7 +140,7 @@ namespace Neo4jClient.Test.GraphClientTests
             })
             {
                 var graphClient = testHarness.CreateAndConnectGraphClient();
-                Assert.AreEqual(CypherCapabilities.Cypher20, graphClient.CypherCapabilities);
+                Assert.AreEqual(CypherCapabilities.Cypher203, graphClient.CypherCapabilities);
             }
         }
 

--- a/Test/MockResponse.cs
+++ b/Test/MockResponse.cs
@@ -43,6 +43,21 @@ namespace Neo4jClient.Test
             }");
         }
 
+        public static MockResponse NeoRoot204()
+        {
+            return Json(HttpStatusCode.OK, @"{
+                'cypher' : 'http://foo/db/data/cypher',
+                'batch' : 'http://foo/db/data/batch',
+                'node' : 'http://foo/db/data/node',
+                'node_index' : 'http://foo/db/data/index/node',
+                'relationship_index' : 'http://foo/db/data/index/relationship',
+                'reference_node' : 'http://foo/db/data/node/123',
+                'neo4j_version' : '2.4.0',
+                'extensions_info' : 'http://foo/db/data/ext',
+                'extensions' : {}
+            }");
+        }
+
         public static MockResponse NeoRoot20()
         {
             return Json(HttpStatusCode.OK, @"{


### PR DESCRIPTION
It also includes an additional method in CypherFluentQuery<TResult> that
was not masking the parent class Unwind() method for collections.