### PR TITLE
Fix for issue #110 https://github.com/Readify/Neo4jClient/issues/110

### DIFF
--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -976,10 +976,16 @@ namespace Neo4jClient
                 var deserializer = new CypherJsonDeserializer<TResult>(this, query.ResultMode, query.ResultFormat,
                     inTransaction);
                 if (inTransaction)
+                {
+                    response.DeserializationContext.DeserializationContext.JsonContractResolver =
+                        query.JsonContractResolver;
                     results =
                         deserializer.DeserializeFromTransactionPartialContext(response.DeserializationContext).ToList();
+                }
                 else
+                {
                     results = deserializer.Deserialize(response.ResponseObject.Content.ReadAsString()).ToList();
+                }
 
             }
             catch (AggregateException aggregateException)


### PR DESCRIPTION
Using a custom JsonContractResolver + TransactionScope causes failed deserialization