### PR TITLE
Check for Transaction Scope Stack being Empty

### DIFF
--- a/Neo4jClient.Tests/Transactions/TransactionManagementTests.cs
+++ b/Neo4jClient.Tests/Transactions/TransactionManagementTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -18,6 +15,73 @@ namespace Neo4jClient.Test.Transactions
     [TestFixture]
     public class TransactionManagementTests
     {
+        [Test]
+        public void EndTransaction_DoesntThrowAnyExceptions_WhenScopedTransactionsIsEmpty()
+        {
+            using (var testHarness = new RestTestHarness())
+            {
+                var client = testHarness.CreateAndConnectTransactionalGraphClient();
+                client.Connect();
+
+                var tm = new Neo4jClient.Transactions.TransactionManager(client)
+                {
+                    ScopedTransactions = new Stack<TransactionScopeProxy>()
+                };
+                Assert.AreEqual(0, tm.ScopedTransactions.Count);
+                tm.EndTransaction();
+            }
+        }
+
+        [Test]
+        public void EndTransaction_DoesntThrowAnyExceptions_WhenScopedTransactionsIsNull()
+        {
+            using (var testHarness = new RestTestHarness())
+            {
+                var client = testHarness.CreateAndConnectTransactionalGraphClient();
+                client.Connect();
+
+                var tm = new Neo4jClient.Transactions.TransactionManager(client)
+                {
+                    ScopedTransactions = null
+                };
+                
+                tm.EndTransaction();
+            }
+        }
+
+        [Test]
+        public void CurrentInternalTransaction_ReturnsNullWhenEmpty()
+        {
+            using (var testHarness = new RestTestHarness())
+            {
+                var client = testHarness.CreateAndConnectTransactionalGraphClient();
+                client.Connect();
+
+                var tm = new Neo4jClient.Transactions.TransactionManager(client)
+                {
+                    ScopedTransactions = new Stack<TransactionScopeProxy>()
+                };
+                Assert.AreEqual(0, tm.ScopedTransactions.Count);
+                Assert.IsNull(tm.CurrentInternalTransaction);
+            }
+        }
+
+        [Test]
+        public void CurrentInternalTransaction_ReturnsNullWhenScopedTransactionsIsNull()
+        {
+            using (var testHarness = new RestTestHarness())
+            {
+                var client = testHarness.CreateAndConnectTransactionalGraphClient();
+                client.Connect();
+
+                var tm = new Neo4jClient.Transactions.TransactionManager(client)
+                {
+                    ScopedTransactions = null
+                };
+                Assert.IsNull(tm.CurrentInternalTransaction);
+            }
+        }
+
         [Test]
         [ExpectedException(typeof (NotSupportedException))]
         public void BeginTransactionShouldFailWithLower20Versions()

--- a/Neo4jClient/Transactions/ITransactionManager.cs
+++ b/Neo4jClient/Transactions/ITransactionManager.cs
@@ -17,6 +17,6 @@ namespace Neo4jClient.Transactions
         ITransaction BeginTransaction(TransactionScopeOption option);
         void EndTransaction();
         void RegisterToTransactionIfNeeded();
-        Task<HttpResponseMessage> EnqueueCypherRequest(string commandDescription, IGraphClient client, CypherQuery query);
+        Task<HttpResponseMessage> EnqueueCypherRequest(string commandDescription, IGraphClient graphClient, CypherQuery query);
     }
 }

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ The official neo4jclient build and nuget package is automated via MyGet [build s
 
 ### Stable [![neo4jclient-tx MyGet Build Status](https://www.myget.org/BuildSource/Badge/neo4jclient-tx?identifier=57c22856-7609-4211-a432-a1ecdf6f1497)](https://www.myget.org/)
 
-### Pre-Release [![neo4jclient-tx MyGet Build Status](https://www.myget.org/BuildSource/Badge/neo4jclient-tx?identifier=d0ddcfa5-4a79-4e0b-84ac-9cf11135c7b1)](https://www.myget.org/)
-
 #### Breaking Changes in 1.1 
 
 * `CollectAs` now returns `IEnumerable<T>` and not `IEnumerable<Node<T>>`


### PR DESCRIPTION
Instead of catching an InvalidOperationException, the stack is now
checked to see if it has any items before Pop / Peek calls are made.