### PR TITLE
Add ability to set the Planner

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryPlannerTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryPlannerTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Neo4jClient.Cypher;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Neo4jClient.Test.Cypher
+{
+    /// <summary>
+    ///     Tests for the UNWIND operator
+    /// </summary>
+    [TestFixture]
+    public class CypherFluentQueryPlannerTests
+    {
+        [Test]
+        public void TestPlannerWithFreeTextConstruction()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            client.CypherCapabilities.Returns(CypherCapabilities.Cypher22);
+
+            var query = new CypherFluentQuery(client)
+                .Planner("FreePlanner")
+                .Query;
+
+            Assert.AreEqual("PLANNER FreePlanner", query.QueryText);
+        }
+
+        [Test, Sequential]
+        public void TestPlannerWithCypherPlannerVariant(
+            [Values(CypherPlanner.CostGreedy,CypherPlanner.CostIdp, CypherPlanner.Rule)] CypherPlanner input, 
+            [Values("COST", "IDP", "RULE")] string expected)
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            client.CypherCapabilities.Returns(CypherCapabilities.Cypher22);
+
+            var query = new CypherFluentQuery(client)
+                .Planner(input)
+                .Query;
+
+            Assert.AreEqual(string.Format("PLANNER {0}", expected), query.QueryText);
+        }
+
+        [Test]
+        [ExpectedException(typeof (InvalidOperationException))]
+        public void ThrowsInvalidOperationException_WhenNeo4jVersionIsLessThan22()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            client.CypherCapabilities.Returns(CypherCapabilities.Cypher19);
+
+            var _ = new CypherFluentQuery(client)
+                .Planner("FreePlanner")
+                .Query;
+        }
+    }
+}

--- a/Neo4jClient.Tests/GraphClientTests/ConnectTests.cs
+++ b/Neo4jClient.Tests/GraphClientTests/ConnectTests.cs
@@ -115,6 +115,16 @@ namespace Neo4jClient.Test.GraphClientTests
         }
 
         [Test]
+        public void ShouldSetCypher22CapabilitiesForPost22Version()
+        {
+            using (var testHarness = new RestTestHarness())
+            {
+                var graphClient = testHarness.CreateAndConnectGraphClient(RestTestHarness.Neo4jVersion.Neo22);
+                Assert.AreEqual(CypherCapabilities.Cypher22, graphClient.CypherCapabilities);
+            }
+        }
+
+        [Test]
         public void ShouldReturnCypher19CapabilitiesForVersion20()
         {
             using (var testHarness = new RestTestHarness

--- a/Neo4jClient.Tests/MockResponse.cs
+++ b/Neo4jClient.Tests/MockResponse.cs
@@ -76,6 +76,22 @@ namespace Neo4jClient.Test
             }");
         }
 
+        public static MockResponse NeoRoot22()
+        {
+            return Json(HttpStatusCode.OK, @"{
+                'cypher' : 'http://foo/db/data/cypher',
+                'batch' : 'http://foo/db/data/batch',
+                'node' : 'http://foo/db/data/node',
+                'node_index' : 'http://foo/db/data/index/node',
+                'relationship_index' : 'http://foo/db/data/index/relationship',
+                'reference_node' : 'http://foo/db/data/node/123',
+                'neo4j_version' : '2.2.1',
+                'transaction': 'http://foo/db/data/transaction',
+                'extensions_info' : 'http://foo/db/data/ext',
+                'extensions' : {}
+            }");
+        }
+
         public static MockResponse NeoRootPre15M02()
         {
             return Json(HttpStatusCode.OK, @"{

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Cypher\CypherFluentQueryMergeTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryMatchTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryRemoveTests.cs" />
+    <Compile Include="Cypher\CypherFluentQueryPlannerTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryUnwindTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryUsingIndexTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryWithParamTests.cs" />

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj.DotSettings
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/Neo4jClient.Tests/Transactions/TransactionManagementTests.cs
+++ b/Neo4jClient.Tests/Transactions/TransactionManagementTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -24,7 +21,7 @@ namespace Neo4jClient.Test.Transactions
         {
             using (var testHarness = new RestTestHarness())
             {
-                var client = testHarness.CreateGraphClient(false);
+                var client = testHarness.CreateGraphClient(RestTestHarness.Neo4jVersion.Neo19);
                 client.Connect();
                 client.BeginTransaction();
             }

--- a/Neo4jClient/Cypher/CypherCapabilities.cs
+++ b/Neo4jClient/Cypher/CypherCapabilities.cs
@@ -5,17 +5,28 @@ namespace Neo4jClient.Cypher
         public readonly static CypherCapabilities Cypher19 = new CypherCapabilities
         {
             SupportsPropertySuffixesForControllingNullComparisons = true,
-            SupportsNullComparisonsWithIsOperator = true
+            SupportsNullComparisonsWithIsOperator = true,
+            SupportsPlanner = false
         };
 
         public readonly static CypherCapabilities Cypher20 = new CypherCapabilities
         {
             SupportsPropertySuffixesForControllingNullComparisons = false,
-            SupportsNullComparisonsWithIsOperator = false
+            SupportsNullComparisonsWithIsOperator = false,
+            SupportsPlanner = false
+        };
+
+
+        public static readonly CypherCapabilities Cypher22 = new CypherCapabilities
+        {
+            SupportsPlanner = true,
+            SupportsPropertySuffixesForControllingNullComparisons = false,
+            SupportsNullComparisonsWithIsOperator = false,
         };
 
         public static readonly CypherCapabilities Default = Cypher20;
 
+        public bool SupportsPlanner { get; set; }
         public bool SupportsPropertySuffixesForControllingNullComparisons { get; set; }
         public bool SupportsNullComparisonsWithIsOperator { get; set; }
     }

--- a/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
@@ -52,7 +52,7 @@ namespace Neo4jClient.Cypher
 
         ICypherFluentQuery<TResult> Return<TResult>(LambdaExpression expression)
         {
-            var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, camelCaseProperties);
+            var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, CamelCaseProperties);
 
             return Mutate<TResult>(w =>
             {
@@ -64,7 +64,7 @@ namespace Neo4jClient.Cypher
 
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(LambdaExpression expression)
         {
-            var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, camelCaseProperties);
+            var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, CamelCaseProperties);
 
             return Mutate<TResult>(w =>
             {

--- a/Neo4jClient/Cypher/CypherFluentQuery`Where.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`Where.cs
@@ -8,19 +8,19 @@ namespace Neo4jClient.Cypher
         internal ICypherFluentQuery Where(LambdaExpression expression)
         {
             return Mutate(w =>
-                w.AppendClause("WHERE " + CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, camelCaseProperties)));
+                w.AppendClause("WHERE " + CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, CamelCaseProperties)));
         }
 
         internal ICypherFluentQuery AndWhere(LambdaExpression expression)
         {
             return Mutate(w =>
-                w.AppendClause(string.Format("AND {0}", CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, camelCaseProperties))));
+                w.AppendClause(string.Format("AND {0}", CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, CamelCaseProperties))));
         }
 
         internal ICypherFluentQuery OrWhere(LambdaExpression expression)
         {
             return Mutate(w =>
-                w.AppendClause(string.Format("OR {0}", CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, camelCaseProperties))));
+                w.AppendClause(string.Format("OR {0}", CypherWhereExpressionBuilder.BuildText(expression, w.CreateParameter, Client.CypherCapabilities, CamelCaseProperties))));
         }
 
         public ICypherFluentQuery Where(string text)

--- a/Neo4jClient/Cypher/CypherFluentQuery`With.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`With.cs
@@ -12,7 +12,7 @@ namespace Neo4jClient.Cypher
 
         ICypherFluentQuery<TResult> With<TResult>(LambdaExpression expression)
         {
-            var withExpression = CypherWithExpressionBuilder.BuildText(expression, camelCaseProperties);
+            var withExpression = CypherWithExpressionBuilder.BuildText(expression, CamelCaseProperties);
 
             return Mutate<TResult>(w =>
             {

--- a/Neo4jClient/Cypher/CypherPlanner.cs
+++ b/Neo4jClient/Cypher/CypherPlanner.cs
@@ -1,0 +1,12 @@
+﻿namespace Neo4jClient.Cypher
+{
+    public enum CypherPlanner
+    {
+        /// <summary>The rule based planner (RULE)</summary>
+        Rule,
+        /// <summary>The new cost based planner (IDP)</summary>
+        CostIdp,
+        /// <summary>The first cost based planner (COST)</summary>
+        CostGreedy
+    }
+}

--- a/Neo4jClient/Cypher/CypherQuery.cs
+++ b/Neo4jClient/Cypher/CypherQuery.cs
@@ -20,13 +20,13 @@ namespace Neo4jClient.Cypher
         readonly IDictionary<string, object> queryParameters;
         readonly CypherResultMode resultMode;
         readonly CypherResultFormat resultFormat;
-		readonly IContractResolver jsonContractResolver;
+        readonly IContractResolver jsonContractResolver;
 
         public CypherQuery(
             string queryText,
             IDictionary<string, object> queryParameters,
             CypherResultMode resultMode,
-			IContractResolver contractResolver = null) :
+            IContractResolver contractResolver = null) :
             this(queryText, queryParameters, resultMode, CypherResultFormat.DependsOnEnvironment, contractResolver)
         {
         }
@@ -36,7 +36,7 @@ namespace Neo4jClient.Cypher
             IDictionary<string, object> queryParameters,
             CypherResultMode resultMode,
             CypherResultFormat resultFormat,
-			IContractResolver contractResolver = null)
+            IContractResolver contractResolver = null)
         {
             this.queryText = queryText;
             this.queryParameters = queryParameters;

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -20,6 +20,8 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery ParserVersion(Version version);
         ICypherFluentQuery ParserVersion(int major, int minor);
 
+        ICypherFluentQuery Planner(string planner);
+        ICypherFluentQuery Planner(CypherPlanner planner);
         ICypherFluentQuery Start(object startBits);
         ICypherFluentQuery Start(IDictionary<string, object> startBits);
         [Obsolete("Use Start(new { identity = startText }) instead. See https://bitbucket.org/Readify/neo4jclient/issue/74/support-nicer-cypher-start-notation for more details about this change.")]
@@ -60,7 +62,7 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> Return<TResult>(string identity);
         [Obsolete("This was an internal that never should have been exposed. If you want to create a projection, you should be using the lambda overload instead. See the 'Using Functions in Return Clauses' and 'Using Custom Text in Return Clauses' sections of https://bitbucket.org/Readify/neo4jclient/wiki/cypher for details of how to do this.", true)]
         ICypherFluentQuery<TResult> Return<TResult>(string identity, CypherResultMode resultMode);
-		ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<TResult>> expression);
+        ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<TResult>> expression);
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);
@@ -78,9 +80,9 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);
 
-		ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity);
+        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity);
 //        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<TResult>> expression);
-		ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, TResult>> expression);
+        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -177,6 +177,8 @@ namespace Neo4jClient
                 if (RootApiResponse.Version < new Version(2, 0))
                     cypherCapabilities = CypherCapabilities.Cypher19;
 
+                if (RootApiResponse.Version >= new Version(2, 2))
+                    cypherCapabilities = CypherCapabilities.Cypher22;
             }
             catch(Exception e)
             {

--- a/Neo4jClient/Neo4jClient.csproj
+++ b/Neo4jClient/Neo4jClient.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Cypher\All.cs" />
     <Compile Include="Cypher\CypherCapabilities.cs" />
     <Compile Include="Cypher\CypherFluentQuery`With.cs" />
+    <Compile Include="Cypher\CypherPlanner.cs" />
     <Compile Include="Cypher\CypherWithExpressionBuilder.cs" />
     <Compile Include="Cypher\ICypherFluentQuery`Where.cs" />
     <Compile Include="Cypher\ICypherFluentQuery`With.cs" />

--- a/Neo4jClient/Neo4jClient.csproj.DotSettings
+++ b/Neo4jClient/Neo4jClient.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Adds the `.Planner` option to the client. (Fixes #115)

Planner can be set in two ways:

    client.Cypher.Planner("IDP").Match(/*etc*/);
    client.Cypher.Planner(CypherPlanner.CostIdp).Match(/*etc*/);

Both result in:

    PLANNER IDP
    MATCH //etc