### PR TITLE
Expression Visitors take read JsonProperty

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryReturnTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryReturnTests.cs
@@ -1,17 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Net;
 using Newtonsoft.Json.Serialization;
 using NSubstitute;
 using NUnit.Framework;
 using Neo4jClient.ApiModels.Cypher;
 using Neo4jClient.Cypher;
+using Newtonsoft.Json;
 
 namespace Neo4jClient.Test.Cypher
 {
-    using System.Linq.Expressions;
-    using System.Text.RegularExpressions;
+    
+    class FooWithJsonProperties
+    {
+        [JsonProperty("bar")]
+        public string Bar { get; set; }
+    }
 
     [TestFixture]
     public class CypherFluentQueryReturnTests
@@ -75,6 +81,17 @@ namespace Neo4jClient.Test.Cypher
             Assert.AreEqual("START n=node({p0})\r\nRETURN n", query.QueryText);
             Assert.AreEqual(3, query.QueryParameters["p0"]);
             Assert.AreEqual(CypherResultFormat.DependsOnEnvironment, query.ResultFormat);
+        }
+
+        [Test]
+        public void ReturnsUsingJsonPropertyValueForNameOfProperty()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .Return(c => c.As<FooWithJsonProperties>().Bar)
+                .Query;
+
+            Assert.AreEqual("RETURN c.bar", query.QueryText);
         }
 
         [Test]

--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryWhereTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryWhereTests.cs
@@ -2,6 +2,7 @@
 using NSubstitute;
 using NUnit.Framework;
 using Neo4jClient.Cypher;
+using Newtonsoft.Json;
 
 namespace Neo4jClient.Test.Cypher
 {
@@ -27,6 +28,21 @@ namespace Neo4jClient.Test.Cypher
         class MockWithNullField
         {
             public string NullField { get; set; }
+        }
+
+        class FooWithJsonProperties
+        {
+            [JsonProperty("bar")]
+            public string Bar { get; set; }
+        }
+
+        [Test]
+        public void UsesJsonPropertyNameOverPropertyName()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client).Where((FooWithJsonProperties foo) => foo.Bar == "Bar").Query;
+
+            Assert.AreEqual("WHERE (foo.bar = {p0})", query.QueryText);
         }
 
         [Test]

--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryWithTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryWithTests.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Serialization;
 using NSubstitute;
 using NUnit.Framework;
 using Neo4jClient.Cypher;
+using Newtonsoft.Json;
 
 namespace Neo4jClient.Test.Cypher
 {
@@ -53,6 +54,17 @@ namespace Neo4jClient.Test.Cypher
                 .Query;
 
             Assert.AreEqual("WITH sum(foo.bar) AS baz", query.QueryText);
+        }
+
+        [Test]
+        public void ShouldReturnSpecificPropertyTakingIntoAccountJsonProperty()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .With(a => a.As<Cypher.FooWithJsonProperties>().Bar)
+                .Query;
+
+            Assert.AreEqual("WITH a.bar", query.QueryText);
         }
 
         [Test]
@@ -175,6 +187,11 @@ namespace Neo4jClient.Test.Cypher
             Assert.AreEqual("WITH a AS Foo", query.QueryText);
         }
 
+        class FooWithJsonProperties
+        {
+            [JsonProperty("bar")]
+            public string Bar { get; set; }
+        }
         public class Commodity
         {
             public string Name { get; set; }

--- a/Neo4jClient.Tests/Extensions/MemberInfoExtensionsTests.cs
+++ b/Neo4jClient.Tests/Extensions/MemberInfoExtensionsTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Neo4jClient.Extensions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Neo4jClient.Test.Extensions
+{
+    [TestFixture]
+    public class MemberInfoExtensionsTests
+    {
+        class Foo
+        {
+            [JsonProperty]
+            public string Property1 { get; set; }
+
+            [JsonProperty("property_2")]
+            public string Property2 { get; set; }
+
+            public string Property3 { get; set; }
+        }
+
+        [TestFixture]
+        public class GetNameUsingJsonPropertyMethod
+        {
+            [Test, ExpectedException(typeof(ArgumentNullException))]
+            public void ThrowsArgumentNullException_WhenMemberInfoIsNull()
+            {
+                MemberInfoExtensions.GetNameUsingJsonProperty(null);
+            }
+
+            [Test]
+            public void ReturnsCorrectName_WhenPropertyHasJsonPropertyAddedButNoNameSet()
+            {
+                const string expected = "Property1";
+
+                var member = typeof (Foo).GetMember("Property1");
+                var actual = member.Single().GetNameUsingJsonProperty();
+
+                Assert.AreEqual(expected, actual);
+            }
+
+            [Test]
+            public void ReturnsCorrectName_WhenPropertyHasJsonPropertyAddedWithNameSet()
+            {
+                const string expected = "property_2";
+
+                var member = typeof(Foo).GetMember("Property2");
+                var actual = member.Single().GetNameUsingJsonProperty();
+
+                Assert.AreEqual(expected, actual);
+            }
+
+            [Test]
+            public void ReturnsCorrectName_WhenPropertyHasNoJsonPropertyAdded()
+            {
+                const string expected = "Property3";
+
+                var member = typeof(Foo).GetMember("Property3");
+                var actual = member.Single().GetNameUsingJsonProperty();
+
+                Assert.AreEqual(expected, actual);
+            }
+
+        }
+    }
+}

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Cypher\CypherWhereExpressionBuilderTests.cs" />
     <Compile Include="Cypher\QueryWriterTests.cs" />
     <Compile Include="Cypher\StartBitFormatterTests.cs" />
+    <Compile Include="Extensions\MemberInfoExtensionsTests.cs" />
     <Compile Include="MockResponseThrows.cs" />
     <Compile Include="MockResponseThrowsException.cs" />
     <Compile Include="Serialization\CypherJsonDeserializerTests.cs" />

--- a/Neo4jClient/Cypher/CypherReturnExpressionBuilder.cs
+++ b/Neo4jClient/Cypher/CypherReturnExpressionBuilder.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Neo4jClient.Extensions;
 using Neo4jClient.Serialization;
 using Newtonsoft.Json;
 
@@ -252,7 +253,7 @@ namespace Neo4jClient.Cypher
                 throw new ArgumentException("Member expressions are only supported off ICypherResultItem.As<TData>(). For example: Return(foo => foo.As<Bar>().Baz).", "expression");
 
             var baseStatement = BuildStatement(innerExpression, false, capabilities, jsonConvertersThatTheDeserializerWillUse);
-            var statement = string.Format("{0}.{1}", baseStatement.ExpressionText, CypherFluentQuery.ApplyCamelCase(camelCaseProperties, expression.Member.Name));
+            var statement = string.Format("{0}.{1}", baseStatement.ExpressionText, CypherFluentQuery.ApplyCamelCase(camelCaseProperties, expression.Member.GetNameUsingJsonProperty()));
 
             return new ExpressionBuild(statement, baseStatement.ResultFormat);
         }

--- a/Neo4jClient/Cypher/CypherWhereExpressionBuilder.cs
+++ b/Neo4jClient/Cypher/CypherWhereExpressionBuilder.cs
@@ -17,7 +17,7 @@ namespace Neo4jClient.Cypher
                 expression.Body.NodeType == ExpressionType.MemberAccess)
                 throw new NotSupportedException("Member access expressions, like Where(f => f.Foo), are not supported because these become ambiguous between C# and Cypher based on how Neo4j handles null values. Use a comparison instead, like Where(f => f.Foo == true).");
 
-            var myVisitor = new CypherWhereExpressionVisitor(createParameterCallback, capabilities,camelCaseProperties);
+            var myVisitor = new CypherWhereExpressionVisitor(createParameterCallback, capabilities, camelCaseProperties);
             myVisitor.Visit(expression);
             return myVisitor.TextOutput.ToString();
         }

--- a/Neo4jClient/Cypher/CypherWhereExpressionVisitor.cs
+++ b/Neo4jClient/Cypher/CypherWhereExpressionVisitor.cs
@@ -3,6 +3,9 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using Neo4jClient.Extensions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Neo4jClient.Cypher
 {
@@ -211,9 +214,11 @@ namespace Neo4jClient.Cypher
                 if (isNullable || propertyType == typeof (string)) nullIdentifier = "?";
             }
 
-            lastWrittenMemberName = string.Format("{0}.{1}{2}", identity, CypherFluentQuery.ApplyCamelCase(camelCaseProperties, node.Member.Name), nullIdentifier);
+            var nodeMemberName = node.Member.GetNameUsingJsonProperty();
+            lastWrittenMemberName = string.Format("{0}.{1}{2}", identity, CypherFluentQuery.ApplyCamelCase(camelCaseProperties, nodeMemberName), nullIdentifier);
             TextOutput.Append(lastWrittenMemberName);
         }
+
 
         void VisitConstantMember(MemberExpression node)
         {

--- a/Neo4jClient/Cypher/CypherWithExpressionBuilder.cs
+++ b/Neo4jClient/Cypher/CypherWithExpressionBuilder.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Neo4jClient.Extensions;
 
 namespace Neo4jClient.Cypher
 {
@@ -142,7 +143,7 @@ namespace Neo4jClient.Cypher
                 throw new ArgumentException("Member expressions are only supported off ICypherResultItem.As<TData>(). For example: Return(foo => foo.As<Bar>().Baz).", "expression");
 
             var baseStatement = BuildStatement(innerExpression, false);
-            var statement = string.Format("{0}.{1}", baseStatement, CypherFluentQuery.ApplyCamelCase(camelCaseProperties, expression.Member.Name));
+            var statement = string.Format("{0}.{1}", baseStatement, CypherFluentQuery.ApplyCamelCase(camelCaseProperties, expression.Member.GetNameUsingJsonProperty()));
 
             return statement;
         }

--- a/Neo4jClient/Extensions/MemberInfoExtensions.cs
+++ b/Neo4jClient/Extensions/MemberInfoExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Neo4jClient.Extensions
+{
+    public static class MemberInfoExtensions
+    {
+        /// <summary>Gets the name of the property, if a <see cref="JsonPropertyAttribute"/> is attached, it will attempt to use that first.</summary>
+        /// <param name="info">The <see cref="MemberInfo"/> to get the name from</param>
+        /// <returns>The name of the property, if a <see cref="JsonPropertyAttribute"/> is attached, it will use that first.</returns>
+        internal static string GetNameUsingJsonProperty(this MemberInfo info)
+        {
+            var jsonProperty = info.GetCustomAttributes(typeof (JsonPropertyAttribute)).FirstOrDefault() as JsonPropertyAttribute;
+            if (jsonProperty == null || string.IsNullOrWhiteSpace(jsonProperty.PropertyName))
+                return info.Name;
+
+            return jsonProperty.PropertyName;
+        }
+    }
+}

--- a/Neo4jClient/Neo4jClient.csproj
+++ b/Neo4jClient/Neo4jClient.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Execution\IExecutionPolicy.cs" />
     <Compile Include="Execution\IExecutionPolicyFactory.cs" />
     <Compile Include="Execution\IHttpClient.cs" />
+    <Compile Include="Extensions\MemberInfoExtensions.cs" />
     <Compile Include="ICypherGraphClient.cs" />
     <Compile Include="Execution\IRequestTypeBuilder.cs" />
     <Compile Include="Execution\IRequestWithPendingContentBuilder.cs" />


### PR DESCRIPTION
The Expression Visitors now read the `JsonProperty` attributes and take
them into account for generating the Cypher queries