### PR TITLE
Timeout for 2.2.6+ is ignored if has errors

### DIFF
--- a/Neo4jClient.Tests/MockResponse.cs
+++ b/Neo4jClient.Tests/MockResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace Neo4jClient.Test
 {
@@ -76,20 +77,21 @@ namespace Neo4jClient.Test
             }");
         }
 
-        public static MockResponse NeoRoot22()
+        public static MockResponse NeoRoot(int v1, int v2, int v3)
         {
-            return Json(HttpStatusCode.OK, @"{
+            var version = string.Format("{0}.{1}.{2}", v1, v2, v3);
+            return Json(HttpStatusCode.OK, string.Format(@"{{
                 'cypher' : 'http://foo/db/data/cypher',
                 'batch' : 'http://foo/db/data/batch',
                 'node' : 'http://foo/db/data/node',
                 'node_index' : 'http://foo/db/data/index/node',
                 'relationship_index' : 'http://foo/db/data/index/relationship',
                 'reference_node' : 'http://foo/db/data/node/123',
-                'neo4j_version' : '2.2.1',
+                'neo4j_version' : '{0}',
                 'transaction': 'http://foo/db/data/transaction',
                 'extensions_info' : 'http://foo/db/data/ext',
-                'extensions' : {}
-            }");
+                'extensions' : {{}}
+            }}", version));
         }
 
         public static MockResponse NeoRootPre15M02()

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Serialization\UserSuppliedSerializationTests.cs" />
     <Compile Include="Transactions\Neo4jTransactionResourceManagerTests.cs" />
     <Compile Include="Transactions\QueriesInTransactionTests.cs" />
+    <Compile Include="Transactions\QueryHelper.cs" />
     <Compile Include="Transactions\RestCallScenarioTests.cs" />
     <Compile Include="Transactions\TransactionManagementTests.cs" />
     <Compile Include="UtilitiesTests.cs" />

--- a/Neo4jClient.Tests/RestTestHarness.cs
+++ b/Neo4jClient.Tests/RestTestHarness.cs
@@ -20,7 +20,11 @@ namespace Neo4jClient.Test
         {
             Neo19,
             Neo20,
-            Neo22
+            Neo22,
+            Neo225,
+            Neo226,
+            Neo23,
+            Neo30
         }
 
         readonly IDictionary<MockRequest, MockResponse> recordedResponses = new Dictionary<MockRequest, MockResponse>();
@@ -64,7 +68,16 @@ namespace Neo4jClient.Test
                         response = MockResponse.NeoRoot20();
                         break;
                     case Neo4jVersion.Neo22:
-                        response = MockResponse.NeoRoot22();
+                        response = MockResponse.NeoRoot(2,2,0);
+                        break;
+                    case Neo4jVersion.Neo225:
+                        response = MockResponse.NeoRoot(2,2,5);
+                        break;
+                    case Neo4jVersion.Neo226:
+                        response = MockResponse.NeoRoot(2,2,6);
+                        break;
+                    case Neo4jVersion.Neo23:
+                        response = MockResponse.NeoRoot(2,3,0);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException("neoVersion", neoVersion, null);

--- a/Neo4jClient.Tests/Transactions/QueriesInTransactionTests.cs
+++ b/Neo4jClient.Tests/Transactions/QueriesInTransactionTests.cs
@@ -18,25 +18,6 @@ namespace Neo4jClient.Test.Transactions
     [TestFixture]
     public class QueriesInTransactionTests
     {
-        private static string ResetTransactionTimer()
-        {
-            return new DateTime().AddSeconds(60).ToString("ddd, dd, MMM yyyy HH:mm:ss +0000");
-        }
-
-        private string GenerateInitTransactionResponse(int id, string results)
-        {
-            return string.Format(
-                @"{{'commit': 'http://foo/db/data/transaction/{0}/commit', 'results': [{1}], 'errors': [], 'transaction': {{ 'expires': '{2}' }} }}",
-                id,
-                results,
-                ResetTransactionTimer()
-            );
-        }
-
-        private string GenerateInitTransactionResponse(int id)
-        {
-            return GenerateInitTransactionResponse(id, string.Empty);
-        }
 
         [Test]
         public void CommitWithoutRequestsShouldNotGenerateMessage()
@@ -46,7 +27,7 @@ namespace Neo4jClient.Test.Transactions
             using (var testHarness = new RestTestHarness
             {
                 {
-                    initTransactionRequest, MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    initTransactionRequest, MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitTransactionRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -71,7 +52,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     keepAliveRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -96,7 +77,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     rollbackTransactionRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -122,7 +103,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     rollbackTransactionRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -155,7 +136,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -200,7 +181,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -242,7 +223,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     secondClientRequest,
@@ -250,7 +231,7 @@ namespace Neo4jClient.Test.Transactions
                 },
                 {
                     afterPspeFailRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(2), "http://foo/db/data/transaction/2")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(2), "http://foo/db/data/transaction/2")
                 },
                 {
                     promoteRequest,
@@ -295,7 +276,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitTransactionRequest,
@@ -345,7 +326,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitTransactionRequest,
@@ -391,7 +372,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     secondRequest,
@@ -435,7 +416,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     deleteRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -471,11 +452,11 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     MockRequest.PostObjectAsJson("/transaction", cypherQueryMsTxStatement),
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
                 },
                 {
                     MockRequest.PostObjectAsJson("/transaction", cypherQueryTxStatement),
-                    MockResponse.Json(201, GenerateInitTransactionResponse(2, resultColumn), "http://foo/db/data/transaction/2")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(2, resultColumn), "http://foo/db/data/transaction/2")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -530,7 +511,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     MockRequest.PostObjectAsJson("/transaction", cypherApiQuery),
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -582,7 +563,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     MockRequest.PostObjectAsJson("/transaction", cypherApiQuery),
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -622,7 +603,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     MockRequest.PostObjectAsJson("/transaction", cypherApiQuery),
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -660,7 +641,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -691,7 +672,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -730,7 +711,7 @@ namespace Neo4jClient.Test.Transactions
             using (var testHarness = new RestTestHarness
             {
                 {
-                    initTransactionRequest, MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    initTransactionRequest, MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     keepAliveRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -766,7 +747,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     deserializationRequest,
@@ -807,7 +788,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     initTransactionRequest,
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1), "http://foo/db/data/transaction/1")
                 },
                 {
                     rollbackTransactionRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -844,7 +825,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     MockRequest.PostObjectAsJson("/transaction", cypherApiQuery),
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
                 },
                 {
                     commitRequest, MockResponse.Json(200, @"{'results':[], 'errors':[] }")
@@ -918,7 +899,7 @@ namespace Neo4jClient.Test.Transactions
 
             testHarness.Add(
                 MockRequest.PostObjectAsJson("/transaction", apiQueries[0]),
-                MockResponse.Json(201, GenerateInitTransactionResponse(1, string.Format(resultColumnBase, 0)),
+                MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1, string.Format(resultColumnBase, 0)),
                     "http://foo/db/data/transaction/1")
                 );
             testHarness.Add(
@@ -982,7 +963,7 @@ namespace Neo4jClient.Test.Transactions
             {
                 {
                     MockRequest.PostObjectAsJson("/transaction", cypherApiQuery),
-                    MockResponse.Json(201, GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
+                    MockResponse.Json(201, TransactionRestResponseHelper.GenerateInitTransactionResponse(1, resultColumn), "http://foo/db/data/transaction/1")
                 }
             })
             {

--- a/Neo4jClient.Tests/Transactions/TransactionRestResponseHelper.cs
+++ b/Neo4jClient.Tests/Transactions/TransactionRestResponseHelper.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Neo4jClient.Test.Transactions
+{
+    internal static class TransactionRestResponseHelper
+    {
+        internal static string ResetTransactionTimer()
+        {
+            return new DateTime().AddSeconds(60).ToString("ddd, dd, MMM yyyy HH:mm:ss +0000");
+        }
+
+        internal static string GenerateInitTransactionResponse(int id, string results)
+        {
+            return string.Format(
+                @"{{'commit': 'http://foo/db/data/transaction/{0}/commit', 'results': [{1}], 'errors': [], 'transaction': {{ 'expires': '{2}' }} }}",
+                id,
+                results, ResetTransactionTimer()
+                );
+        }
+
+        internal static string GenerateInitTransactionResponse(int id)
+        {
+            return GenerateInitTransactionResponse(id, string.Empty);
+        }
+
+        internal static string GenerateCypherErrorResponse(int id,  string error, string results = "")
+        {
+            return string.Format(
+                @"{{'commit': 'http://foo/db/data/transaction/{0}/commit', 'results': [{1}], 'errors': [{2}], 'transaction': {{ 'expires': '{3}' }} }}",
+                id,
+                results,
+                error, 
+                ResetTransactionTimer()
+                );
+        }
+    }
+}

--- a/Neo4jClient/Cypher/CypherCapabilities.cs
+++ b/Neo4jClient/Cypher/CypherCapabilities.cs
@@ -10,6 +10,7 @@ namespace Neo4jClient.Cypher
             SupportsPlanner = cypherCapabilities.SupportsPlanner;
             SupportsNullComparisonsWithIsOperator = cypherCapabilities.SupportsNullComparisonsWithIsOperator;
             SupportsPropertySuffixesForControllingNullComparisons = cypherCapabilities.SupportsPropertySuffixesForControllingNullComparisons;
+            AutoRollsBackOnError = cypherCapabilities.AutoRollsBackOnError;
         }
 
         public readonly static CypherCapabilities Cypher19 = new CypherCapabilities
@@ -25,13 +26,15 @@ namespace Neo4jClient.Cypher
         };
 
         public static readonly CypherCapabilities Cypher22 = new CypherCapabilities(Cypher20){SupportsPlanner = true};
-        public static readonly CypherCapabilities Cypher23 = new CypherCapabilities(Cypher22) {SupportsStartsWith = true};
-
+        public static readonly CypherCapabilities Cypher226 = new CypherCapabilities(Cypher22) { AutoRollsBackOnError = true };
+        public static readonly CypherCapabilities Cypher23 = new CypherCapabilities(Cypher226) {SupportsStartsWith = true};
         public static readonly CypherCapabilities Default = Cypher20;
 
         public bool SupportsPlanner { get; set; }
         public bool SupportsPropertySuffixesForControllingNullComparisons { get; set; }
         public bool SupportsNullComparisonsWithIsOperator { get; set; }
         public bool SupportsStartsWith { get; set; }
+
+        public bool AutoRollsBackOnError { get; set; }
     }
 }

--- a/Neo4jClient/Execution/ExecutionConfiguration.cs
+++ b/Neo4jClient/Execution/ExecutionConfiguration.cs
@@ -13,5 +13,6 @@ namespace Neo4jClient.Execution
         public IEnumerable<JsonConverter> JsonConverters { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public bool HasErrors { get; set; }
     }
 }

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -180,6 +180,9 @@ namespace Neo4jClient
                 if (RootApiResponse.Version >= new Version(2, 2))
                     cypherCapabilities = CypherCapabilities.Cypher22;
 
+                if (RootApiResponse.Version >= new Version(2, 2, 6))
+                    cypherCapabilities = CypherCapabilities.Cypher226;
+
                 if (RootApiResponse.Version >= new Version(2, 3))
                     cypherCapabilities = CypherCapabilities.Cypher23;
             }
@@ -1028,6 +1031,9 @@ namespace Neo4jClient
             }
             catch (AggregateException ex)
             {
+                if (InTransaction)
+                    ExecutionConfiguration.HasErrors = true;
+
                 Exception unwrappedException;
                 if (ex.TryUnwrap(out unwrappedException))
                 {
@@ -1038,6 +1044,7 @@ namespace Neo4jClient
                 context.Complete(query, ex);
                 throw;
             }
+     
             context.Policy.AfterExecution(TransactionHttpUtils.GetMetadataFromResponse(task.Result.ResponseObject), null);
 
             context.Complete(query);
@@ -1501,6 +1508,7 @@ namespace Neo4jClient
             private readonly Stopwatch stopwatch;
 
             public IExecutionPolicy Policy { get; set; }
+            public static bool HasErrors { get; set; }
 
             private ExecutionContext()
             {

--- a/Neo4jClient/Transactions/Neo4jTransaction.cs
+++ b/Neo4jClient/Transactions/Neo4jTransaction.cs
@@ -110,9 +110,14 @@ namespace Neo4jClient.Transactions
                 return;
             }
 
+            //This change is due to: https://github.com/Readify/Neo4jClient/issues/127 and https://github.com/neo4j/neo4j/issues/5806 - 
+            HttpStatusCode[] expectedStatusCodes = {HttpStatusCode.OK};
+            if (_client.CypherCapabilities.AutoRollsBackOnError && _client.ExecutionConfiguration.HasErrors)
+                    expectedStatusCodes = new [] {HttpStatusCode.OK, HttpStatusCode.NotFound};
+
             Request.With(_client.ExecutionConfiguration)
                 .Delete(Endpoint)
-                .WithExpectedStatusCodes(HttpStatusCode.OK)
+                .WithExpectedStatusCodes(expectedStatusCodes)
                 .Execute();
 
             CleanupAfterClosedTransaction();


### PR DESCRIPTION
In 2.2.6+ of Neo4j any Cypher error was set to Rollback automatically.
This commit makes the client ignore a 404 response *only* if the version
of Neo4j is > 2.2.6 AND a Cypher Error has occurred. The 404 would still
be seen for a genuine timeout.

This will fix #127 