### PR TITLE
Respect Cypher capability detection for null suffixes in WHERE clauses

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryWithTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryWithTests.cs
@@ -79,6 +79,36 @@ namespace Neo4jClient.Test.Cypher
         }
 
         [Test]
+        public void ShouldReturnSpecificPropertyWithAliasWithNullableSuffixInCypher19()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            client.CypherCapabilities.Returns(CypherCapabilities.Cypher19);
+            var query = new CypherFluentQuery(client)
+                .With(a => new
+                {
+                    SomeAlias = a.As<Commodity>().Name
+                })
+                .Query;
+
+            Assert.AreEqual("WITH a.Name? AS SomeAlias", query.QueryText);
+        }
+
+        [Test]
+        public void ShouldReturnSpecificPropertyWithAliasWithoutNullableSuffixInCypher20()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            client.CypherCapabilities.Returns(CypherCapabilities.Cypher20);
+            var query = new CypherFluentQuery(client)
+                .With(a => new
+                {
+                    SomeAlias = a.As<Commodity>().Name
+                })
+                .Query;
+
+            Assert.AreEqual("WITH a.Name AS SomeAlias", query.QueryText);
+        }
+
+        [Test]
         public void ShouldReturnSpecificPropertyOnItsOwnCamelAs()
         {
             var client = Substitute.For<IRawGraphClient>();
@@ -87,7 +117,7 @@ namespace Neo4jClient.Test.Cypher
                 .With(a => new Commodity(){ Name = a.As<Commodity>().Name})
                 .Query;
 
-            Assert.AreEqual("WITH a.name? AS Name", query.QueryText);
+            Assert.AreEqual("WITH a.name AS Name", query.QueryText);
         }
 
         [Test]

--- a/Neo4jClient/Cypher/CypherFluentQuery`With.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`With.cs
@@ -12,7 +12,8 @@ namespace Neo4jClient.Cypher
 
         ICypherFluentQuery<TResult> With<TResult>(LambdaExpression expression)
         {
-            var withExpression = CypherWithExpressionBuilder.BuildText(expression, CamelCaseProperties);
+            var expressionBuilder = new CypherWithExpressionBuilder(Client.CypherCapabilities, CamelCaseProperties);
+            var withExpression = expressionBuilder.BuildText(expression);
 
             return Mutate<TResult>(w =>
             {


### PR DESCRIPTION
Some of the flows in `.Where` are still suffixing properties with `?`, which is Cypher 1.9. There was nothing in the generation to respect the capability detection.