### PR TITLE
Make NeoException serializable

### DIFF
--- a/Neo4jClient/NeoException.cs
+++ b/Neo4jClient/NeoException.cs
@@ -3,6 +3,7 @@ using Neo4jClient.ApiModels;
 
 namespace Neo4jClient
 {
+    [Serializable]
     public class NeoException : ApplicationException
     {
         readonly string neoMessage;


### PR DESCRIPTION
Currently NeoExceptions aren't serializable 'out of the box' and some systems that rely on Exceptions being serializable can't send NeoExceptions around.