### PR TITLE
Allow CypherQuery to have a null value for parameters

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherQueryTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherQueryTests.cs
@@ -8,6 +8,15 @@ namespace Neo4jClient.Test.Cypher
     public class CypherQueryTests
     {
         [Test]
+        public void DebugQueryShouldBeSuccessfulWithNullAsParameters()
+        {
+            var query = new CypherQuery("MATCH (n) RETURN (n)", null, CypherResultMode.Set);
+
+            const string expected = "MATCH (n) RETURN (n)";
+            Assert.AreEqual(expected, query.DebugQueryText);
+        }
+
+        [Test]
         public void DebugQueryTextShouldPreserveNewLines()
         {
             var client = Substitute.For<IRawGraphClient>();

--- a/Neo4jClient.Tests/GraphClientTests/Cypher/ExecuteCypherTests.cs
+++ b/Neo4jClient.Tests/GraphClientTests/Cypher/ExecuteCypherTests.cs
@@ -15,6 +15,32 @@ namespace Neo4jClient.Test.GraphClientTests.Cypher
     [TestFixture]
     public class ExecuteCypherTests
     {
+        /// <summary>
+        ///     When executing cypher queries when no parameters are needed, the REST interface doesn't care if we don't send parameters.
+        /// </summary>
+        [Test]
+        public void SendingNullParametersShouldNotRaiseExceptionWhenExecutingCypher()
+        {
+            const string queryText = @"MATCH (d) RETURN d";
+            
+            var cypherQuery = new CypherQuery(queryText, null, CypherResultMode.Set, CypherResultFormat.Rest);
+            var cypherApiQuery = new CypherApiQuery(cypherQuery);
+
+            using (var testHarness = new RestTestHarness
+            {
+                {
+                    MockRequest.PostObjectAsJson("/cypher", cypherApiQuery),
+                    MockResponse.Http((int)HttpStatusCode.OK)
+                }
+            })
+            {
+                var graphClient = testHarness.CreateAndConnectGraphClient();
+
+                // execute cypher with "null" parameters
+                graphClient.ExecuteCypher(cypherQuery);
+            }
+        }
+
         [Test]
         public void ShouldSendCommandAndNotCareAboutResults()
         {

--- a/Neo4jClient/Cypher/CypherQuery.cs
+++ b/Neo4jClient/Cypher/CypherQuery.cs
@@ -101,6 +101,11 @@ namespace Neo4jClient.Cypher
         {
             get
             {
+                if (queryParameters == null)
+                {
+                    return queryText;
+                }
+
                 var serializer = BuildSerializer();
                 var text = queryParameters
                     .Keys

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -1092,7 +1092,7 @@ namespace Neo4jClient
                                     transactionManager.CurrentDtcTransaction;
             context.Policy.AfterExecution(TransactionHttpUtils.GetMetadataFromResponse(response), transactionObject);
             
-            context.Complete(string.Join(", ", queryList.Select(query => query.DebugQueryText)));
+            context.Complete(string.Join(", ", queryList.Select(query => query.QueryText)));
         }
 
         [Obsolete(
@@ -1545,17 +1545,17 @@ namespace Neo4jClient
 
             public void Complete(CypherQuery query)
             {
-                Complete(query.DebugQueryText, 0, null);
+                Complete(query.QueryText, 0, null);
             }
 
             public void Complete(CypherQuery query, int resultsCount)
             {
-                Complete(query.DebugQueryText, resultsCount, null, query.CustomHeaders);
+                Complete(query.QueryText, resultsCount, null, query.CustomHeaders);
             }
 
             public void Complete(CypherQuery query, Exception exception)
             {
-                Complete(query.DebugQueryText, -1, exception);
+                Complete(query.QueryText, -1, exception);
             }
 
             public void Complete(string queryText, int resultsCount = -1, Exception exception = null, NameValueCollection customHeaders = null, int? maxExecutionTime = null)

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -1092,7 +1092,7 @@ namespace Neo4jClient
                                     transactionManager.CurrentDtcTransaction;
             context.Policy.AfterExecution(TransactionHttpUtils.GetMetadataFromResponse(response), transactionObject);
             
-            context.Complete(string.Join(", ", queryList.Select(query => query.QueryText)));
+            context.Complete(OperationCompleted != null ? string.Join(", ", queryList.Select(query => query.DebugQueryText)) : string.Empty);
         }
 
         [Obsolete(
@@ -1545,17 +1545,20 @@ namespace Neo4jClient
 
             public void Complete(CypherQuery query)
             {
-                Complete(query.QueryText, 0, null);
+                // only parse the events when there's an event handler
+                Complete(owner.OperationCompleted != null ? query.DebugQueryText : string.Empty, 0, null);
             }
 
             public void Complete(CypherQuery query, int resultsCount)
             {
-                Complete(query.QueryText, resultsCount, null, query.CustomHeaders);
+                // only parse the events when there's an event handler
+                Complete(owner.OperationCompleted != null ? query.DebugQueryText : string.Empty, resultsCount, null, query.CustomHeaders);
             }
 
             public void Complete(CypherQuery query, Exception exception)
             {
-                Complete(query.QueryText, -1, exception);
+                // only parse the events when there's an event handler
+                Complete(owner.OperationCompleted != null ? query.DebugQueryText : string.Empty, -1, exception);
             }
 
             public void Complete(string queryText, int resultsCount = -1, Exception exception = null, NameValueCollection customHeaders = null, int? maxExecutionTime = null)


### PR DESCRIPTION
As some queries do not require parameters (like a simple MATCH n RETURN n), sending a null instead of an empty dictionary for parameters also make sense. And even if we don't want that behavior we have allow it so far as the library does not throw an ArgumentNullException.

If you do pass on a null dictionary, then the library crashes when the query has been already executed as within `ExecuteCypher` there is a call to `context.Complete()` which receives the `CypherQuery` instance and uses the `DebugQueryText` as the query text that will be sent to the event handler, which in turns parses the parameters and substitute the values within the query where they are being referenced.

First of all, `DebugQueryText` should not be used for this purpose as `context.Complete()` is executed for _every_ cypher request that the library does. This problem was actually introduced recently in commit 249d95b8887ab78c5c0a0185c309ec05dccb6515 I'm rolling back this change by using the`QueryText` property.

And finally, if you do send a null as the parameters dictionary, Visual Studio or any other IDE which evaluates this property thanks to the `DebuggerDisplayAttribute` applied to the `CypherFluentQuery` class definition will throw an exception when evaluating the property. I am including a check for such cases.

