### PR TITLE
Issue 141

### DIFF
--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -1090,9 +1090,14 @@ namespace Neo4jClient
 
             var transactionObject = transactionManager.CurrentNonDtcTransaction ??
                                     transactionManager.CurrentDtcTransaction;
+
+            if (customHeaders != null && customHeaders.Count > 0)
+            {
+                transactionObject.CustomHeaders = customHeaders;
+            }
+
             context.Policy.AfterExecution(TransactionHttpUtils.GetMetadataFromResponse(response), transactionObject);
-            
-            context.Complete(string.Join(", ", queryList.Select(query => query.DebugQueryText)));
+            context.Complete(string.Join(", ", queryList.Select(query => query.DebugQueryText)), -1, null, customHeaders);
         }
 
         [Obsolete(

--- a/Neo4jClient/Transactions/ITransaction.cs
+++ b/Neo4jClient/Transactions/ITransaction.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Specialized;
 
 namespace Neo4jClient.Transactions
 {
@@ -31,5 +32,11 @@ namespace Neo4jClient.Transactions
         /// Commit() or Rollback().
         /// </summary>
         bool IsOpen { get; }
+
+        /// <summary>
+        /// Customheader collection This will be the same for the entire transaction.
+        /// So the commit will use the same customheader(s) as the cypher customheader
+        /// </summary>
+        NameValueCollection CustomHeaders { get; set; }
     }
 }

--- a/Neo4jClient/Transactions/TransactionContext.cs
+++ b/Neo4jClient/Transactions/TransactionContext.cs
@@ -125,6 +125,10 @@ namespace Neo4jClient.Transactions
                 _cancellationTokenSource.Cancel();
                 throw new InvalidOperationException("Cannot commit unless all tasks have been completed");
             }
+            if (CustomHeaders != null)
+            {
+                Transaction.CustomHeaders = CustomHeaders;
+            }
             Transaction.Commit();
         }
 

--- a/Neo4jClient/Transactions/TransactionScopeProxy.cs
+++ b/Neo4jClient/Transactions/TransactionScopeProxy.cs
@@ -60,6 +60,10 @@ namespace Neo4jClient.Transactions
         public void Commit()
         {
             _markCommitted = true;
+            if (CustomHeaders != null)
+            {
+                _transactionContext.CustomHeaders = CustomHeaders;
+            }
             DoCommit();
         }
 


### PR DESCRIPTION
#*%&($% :-) After some internal tests. It looked like the way ExecuteMultipleCypherQueriesInTransaction worked with transaction was different then I expected. So I added a unittest. And extended the transaction flow to use the same customheaders across that transaction. 