### PR TITLE
NeoServerConfiguration added

### DIFF
--- a/Neo4jClient.Tests/GraphClientTests/FactoryTests.cs
+++ b/Neo4jClient.Tests/GraphClientTests/FactoryTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Neo4jClient.Test.GraphClientTests
+{
+    [TestFixture]
+    public class FactoryTests
+    {
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ShouldThrowExceptionIfConfigurationIsNotDefined()
+        {
+            new GraphClientFactory(null);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ShouldThrowExceptionIfRootApiIsNotDefined()
+        {
+            using (var testHarness = new RestTestHarness())
+            {
+                var config = NeoServerConfiguration.GetConfiguration(new Uri(testHarness.BaseUri));
+
+                config.ApiConfig = null;
+
+                new GraphClientFactory(config);
+            }
+        }
+    }
+}

--- a/Neo4jClient.Tests/GraphClientTests/FactoryTests.cs
+++ b/Neo4jClient.Tests/GraphClientTests/FactoryTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Net;
+using System.Threading.Tasks;
+using Neo4jClient.ApiModels.Cypher;
+using Neo4jClient.Cypher;
 using Neo4jClient.Execution;
 using NUnit.Framework;
 
@@ -36,6 +39,42 @@ namespace Neo4jClient.Test.GraphClientTests
                 };
 
                 NeoServerConfiguration.GetConfiguration(new Uri(testHarness.BaseUri), null, null, executeConfiguration);
+            }
+        }
+
+        [Test]
+        public void GraphClientFactoryUseCase()
+        {
+            const string queryText = @"MATCH (d) RETURN d";
+
+            var cypherQuery = new CypherQuery(queryText, null, CypherResultMode.Set, CypherResultFormat.Rest);
+            var cypherApiQuery = new CypherApiQuery(cypherQuery);
+
+            using (var testHarness = new RestTestHarness
+            {
+                { MockRequest.Get("/"), MockResponse.NeoRoot() },
+                { MockRequest.PostObjectAsJson("/cypher", cypherApiQuery), new MockResponse { StatusCode = HttpStatusCode.OK } }
+            })
+            {
+                var httpClient = testHarness.GenerateHttpClient(testHarness.BaseUri);
+
+                var executeConfiguration = new ExecutionConfiguration
+                {
+                    HttpClient = httpClient,
+                    UserAgent =
+                        string.Format("Neo4jClient/{0}", typeof(NeoServerConfiguration).Assembly.GetName().Version),
+                    UseJsonStreaming = true,
+                    JsonConverters = GraphClient.DefaultJsonConverters
+                };
+
+                var configuration = NeoServerConfiguration.GetConfiguration(new Uri(testHarness.BaseUri), null, null, executeConfiguration);
+
+                var factory = new GraphClientFactory(configuration);
+
+                using (var client = factory.Create(httpClient))
+                {
+                    client.Cypher.Match("(d)").Return<object>("d").ExecuteWithoutResults();
+                }
             }
         }
     }

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Cypher\QueryWriterTests.cs" />
     <Compile Include="Cypher\StartBitFormatterTests.cs" />
     <Compile Include="Extensions\MemberInfoExtensionsTests.cs" />
+    <Compile Include="GraphClientTests\FactoryTests.cs" />
     <Compile Include="MockResponseThrows.cs" />
     <Compile Include="MockResponseThrowsException.cs" />
     <Compile Include="Serialization\CypherJsonDeserializerTests.cs" />

--- a/Neo4jClient/Execution/ExecutionConfiguration.cs
+++ b/Neo4jClient/Execution/ExecutionConfiguration.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Neo4jClient.Execution
 {
-
     public class ExecutionConfiguration
     {
         public IHttpClient HttpClient { get; set; }

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -49,7 +49,7 @@ namespace Neo4jClient
         private RootNode rootNode;
 
         private CypherCapabilities cypherCapabilities = CypherCapabilities.Default;
-
+        
 
         public bool UseJsonStreamingIfAvailable { get; set; }
 
@@ -939,7 +939,7 @@ namespace Neo4jClient
                     ResponseObject = response.Result
                 });
         }
-
+        
         IEnumerable<TResult> IRawGraphClient.ExecuteGetCypherResults<TResult>(CypherQuery query)
         {
             var task = ((IRawGraphClient) this).ExecuteGetCypherResultsAsync<TResult>(query);
@@ -954,7 +954,7 @@ namespace Neo4jClient
                     throw unwrappedException;
                 throw;
             }
-
+            
             return task.Result;
         }
 
@@ -1007,7 +1007,7 @@ namespace Neo4jClient
 
             return results;
         }
-
+        
         void IRawGraphClient.ExecuteCypher(CypherQuery query)
         {
             var context = ExecutionContext.Begin(this);
@@ -1037,14 +1037,14 @@ namespace Neo4jClient
 
             context.Complete(query);
         }
-
+        
         async Task IRawGraphClient.ExecuteCypherAsync(CypherQuery query)
         {
             var context = ExecutionContext.Begin(this);
-
+            
             var response = await PrepareCypherRequest<object>(query, context.Policy);
             context.Policy.AfterExecution(TransactionHttpUtils.GetMetadataFromResponse(response.ResponseObject), null);
-
+            
             context.Complete(query);
         }
 

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -195,11 +195,11 @@ namespace Neo4jClient
             where TNode : class
         {
             if (typeof (TNode).IsGenericType &&
-                typeof (TNode).GetGenericTypeDefinition() == typeof(Node<>))
+                typeof (TNode).GetGenericTypeDefinition() == typeof (Node<>))
             {
                 throw new ArgumentException(string.Format(
                     "You're trying to pass in a Node<{0}> instance. Just pass the {0} instance instead.",
-                    typeof(TNode).GetGenericArguments()[0].Name),
+                    typeof (TNode).GetGenericArguments()[0].Name),
                     "node");
             }
 
@@ -219,7 +219,7 @@ namespace Neo4jClient
                 .Cast<Relationship>()
                 .Select(r => new
                 {
-                    CalculatedDirection = Relationship.DetermineRelationshipDirection(typeof(TNode), r),
+                    CalculatedDirection = Relationship.DetermineRelationshipDirection(typeof (TNode), r),
                     Relationship = r
                 })
                 .ToArray();
@@ -442,7 +442,7 @@ namespace Neo4jClient
         public virtual RelationshipInstance<TData> Get<TData>(RelationshipReference<TData> reference)
             where TData : class, new()
         {
-            return Get<TData>((RelationshipReference)reference);
+            return Get<TData>((RelationshipReference) reference);
         }
 
         public virtual RelationshipInstance<TData> Get<TData>(RelationshipReference reference)
@@ -1283,7 +1283,7 @@ namespace Neo4jClient
             var updates = indexEntries
                 .SelectMany(
                     i => i.KeyValues,
-                    (i, kv) => new {IndexName = i.Name, kv.Key, kv.Value })
+                    (i, kv) => new {IndexName = i.Name, kv.Key, kv.Value})
                 .Where(update => update.Value != null)
                 .ToList();
 
@@ -1362,8 +1362,8 @@ namespace Neo4jClient
         private string BuildRelativeIndexAddress(string indexName, IndexFor indexFor)
         {
             var baseUri = indexFor == IndexFor.Node
-                ? new UriBuilder() {Path = RootApiResponse.NodeIndex }
-                : new UriBuilder() {Path = RootApiResponse.RelationshipIndex };
+                ? new UriBuilder() {Path = RootApiResponse.NodeIndex}
+                : new UriBuilder() {Path = RootApiResponse.RelationshipIndex};
             return baseUri.Uri.AddPath(Uri.EscapeDataString(indexName)).LocalPath;
         }
 

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -23,7 +23,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Neo4jClient
 {
-    public class GraphClient : IRawGraphClient, IInternalTransactionalGraphClient, IDisposable
+    public class GraphClient : IRawGraphClient, IInternalTransactionalGraphClient
     {
         internal const string GremlinPluginUnavailable =
             "You're attempting to execute a Gremlin query, however the server instance you are connected to does not have the Gremlin plugin loaded. If you've recently upgraded to Neo4j 2.0, you'll need to be aware that Gremlin no longer ships as part of the normal Neo4j distribution.  Please move to equivalent (but much more powerful and readable!) Cypher.";

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -37,7 +37,7 @@ namespace Neo4jClient
             new EnumValueConverter()
         };
 
-        public static readonly DefaultContractResolver DefaultJsonContractResolver = new DefaultContractResolver();
+        public static readonly DefaultContractResolver DefaultJsonContractResolver  = new DefaultContractResolver();
 
         private ITransactionManager transactionManager;
         private readonly IExecutionPolicyFactory policyFactory;
@@ -49,6 +49,7 @@ namespace Neo4jClient
         private RootNode rootNode;
 
         private CypherCapabilities cypherCapabilities = CypherCapabilities.Default;
+
 
         public bool UseJsonStreamingIfAvailable { get; set; }
 
@@ -163,7 +164,7 @@ namespace Neo4jClient
                 if (RootApiResponse.Version >= new Version(2, 3))
                     cypherCapabilities = CypherCapabilities.Cypher23;
             }
-            catch (Exception e)
+            catch(Exception e)
             {
                 operationCompletedArgs.Exception = e;
                 stopTimerAndNotifyCompleted();
@@ -193,8 +194,8 @@ namespace Neo4jClient
             IEnumerable<IndexEntry> indexEntries)
             where TNode : class
         {
-            if (typeof(TNode).IsGenericType &&
-                typeof(TNode).GetGenericTypeDefinition() == typeof(Node<>))
+            if (typeof (TNode).IsGenericType &&
+                typeof (TNode).GetGenericTypeDefinition() == typeof(Node<>))
             {
                 throw new ArgumentException(string.Format(
                     "You're trying to pass in a Node<{0}> instance. Just pass the {0} instance instead.",
@@ -293,7 +294,7 @@ namespace Neo4jClient
             stopwatch.Stop();
             OnOperationCompleted(new OperationCompletedEventArgs
             {
-                QueryText = string.Format("Create<{0}>", typeof(TNode).Name),
+                QueryText = string.Format("Create<{0}>", typeof (TNode).Name),
                 ResourcesReturned = 0,
                 TimeTaken = stopwatch.Elapsed
             });
@@ -373,7 +374,7 @@ namespace Neo4jClient
 
         public ISerializer Serializer
         {
-            get { return new CustomJsonSerializer { JsonConverters = JsonConverters, JsonContractResolver = JsonContractResolver }; }
+            get { return new CustomJsonSerializer { JsonConverters = JsonConverters , JsonContractResolver = JsonContractResolver}; }
         }
 
         public void DeleteRelationship(RelationshipReference reference)
@@ -391,7 +392,7 @@ namespace Neo4jClient
                 .FailOnCondition(response => response.StatusCode == HttpStatusCode.NotFound)
                 .WithError(response => new ApplicationException(string.Format(
                     "Unable to delete the relationship. The response status was: {0} {1}",
-                    (int)response.StatusCode,
+                    (int) response.StatusCode,
                     response.ReasonPhrase)))
                 .Execute();
 
@@ -435,7 +436,7 @@ namespace Neo4jClient
 
         public virtual Node<TNode> Get<TNode>(NodeReference<TNode> reference)
         {
-            return Get<TNode>((NodeReference)reference);
+            return Get<TNode>((NodeReference) reference);
         }
 
         public virtual RelationshipInstance<TData> Get<TData>(RelationshipReference<TData> reference)
@@ -503,7 +504,7 @@ namespace Neo4jClient
             stopwatch.Stop();
             OnOperationCompleted(new OperationCompletedEventArgs
             {
-                QueryText = string.Format("Update<{0}> {1}", typeof(TNode).Name, nodeReference.Id),
+                QueryText = string.Format("Update<{0}> {1}", typeof (TNode).Name, nodeReference.Id),
                 ResourcesReturned = 0,
                 TimeTaken = stopwatch.Elapsed
             });
@@ -522,7 +523,7 @@ namespace Neo4jClient
 
             var node = Get(nodeReference);
 
-            var indexEntries = new IndexEntry[] { };
+            var indexEntries = new IndexEntry[] {};
 
             if (indexEntriesCallback != null)
             {
@@ -538,11 +539,11 @@ namespace Neo4jClient
             if (changeCallback != null)
             {
                 var originalValuesDictionary =
-                    new CustomJsonDeserializer(JsonConverters, resolver: JsonContractResolver).Deserialize<Dictionary<string, string>>(
+                    new CustomJsonDeserializer(JsonConverters,resolver:JsonContractResolver).Deserialize<Dictionary<string, string>>(
                         originalValuesString);
                 var newValuesString = serializer.Serialize(node.Data);
                 var newValuesDictionary =
-                    new CustomJsonDeserializer(JsonConverters, resolver: JsonContractResolver).Deserialize<Dictionary<string, string>>(newValuesString);
+                    new CustomJsonDeserializer(JsonConverters,resolver:JsonContractResolver).Deserialize<Dictionary<string, string>>(newValuesString);
                 var differences = Utilities.GetDifferencesBetweenDictionaries(originalValuesDictionary,
                     newValuesDictionary);
                 changeCallback(differences);
@@ -562,7 +563,7 @@ namespace Neo4jClient
             stopwatch.Stop();
             OnOperationCompleted(new OperationCompletedEventArgs
             {
-                QueryText = string.Format("Update<{0}> {1}", typeof(TNode).Name, nodeReference.Id),
+                QueryText = string.Format("Update<{0}> {1}", typeof (TNode).Name, nodeReference.Id),
                 ResourcesReturned = 0,
                 TimeTaken = stopwatch.Elapsed
             });
@@ -600,7 +601,7 @@ namespace Neo4jClient
             stopwatch.Stop();
             OnOperationCompleted(new OperationCompletedEventArgs
             {
-                QueryText = string.Format("Update<{0}> {1}", typeof(TRelationshipData).Name, relationshipReference.Id),
+                QueryText = string.Format("Update<{0}> {1}", typeof (TRelationshipData).Name, relationshipReference.Id),
                 ResourcesReturned = 0,
                 TimeTaken = stopwatch.Elapsed
             });
@@ -626,7 +627,7 @@ namespace Neo4jClient
                 .FailOnCondition(response => response.StatusCode == HttpStatusCode.Conflict)
                 .WithError(response => new ApplicationException(string.Format(
                     "Unable to delete the node. The node may still have relationships. The response status was: {0} {1}",
-                    (int)response.StatusCode,
+                    (int) response.StatusCode,
                     response.ReasonPhrase)))
                 .Execute();
 
@@ -870,7 +871,7 @@ namespace Neo4jClient
                 .ParseAs<List<List<GremlinTableCapResponse>>>()
                 .Execute(string.Format("The query was: {0}", query.QueryText));
 
-            var responses = response ?? new List<List<GremlinTableCapResponse>> { new List<GremlinTableCapResponse>() };
+            var responses = response ?? new List<List<GremlinTableCapResponse>> {new List<GremlinTableCapResponse>()};
 
             stopwatch.Stop();
             OnOperationCompleted(new OperationCompletedEventArgs
@@ -941,7 +942,7 @@ namespace Neo4jClient
 
         IEnumerable<TResult> IRawGraphClient.ExecuteGetCypherResults<TResult>(CypherQuery query)
         {
-            var task = ((IRawGraphClient)this).ExecuteGetCypherResultsAsync<TResult>(query);
+            var task = ((IRawGraphClient) this).ExecuteGetCypherResultsAsync<TResult>(query);
             try
             {
                 Task.WaitAll(task);
@@ -1282,7 +1283,7 @@ namespace Neo4jClient
             var updates = indexEntries
                 .SelectMany(
                     i => i.KeyValues,
-                    (i, kv) => new { IndexName = i.Name, kv.Key, kv.Value })
+                    (i, kv) => new {IndexName = i.Name, kv.Key, kv.Value })
                 .Where(update => update.Value != null)
                 .ToList();
 
@@ -1361,8 +1362,8 @@ namespace Neo4jClient
         private string BuildRelativeIndexAddress(string indexName, IndexFor indexFor)
         {
             var baseUri = indexFor == IndexFor.Node
-                ? new UriBuilder() { Path = RootApiResponse.NodeIndex }
-                : new UriBuilder() { Path = RootApiResponse.RelationshipIndex };
+                ? new UriBuilder() {Path = RootApiResponse.NodeIndex }
+                : new UriBuilder() {Path = RootApiResponse.RelationshipIndex };
             return baseUri.Uri.AddPath(Uri.EscapeDataString(indexName)).LocalPath;
         }
 
@@ -1376,11 +1377,11 @@ namespace Neo4jClient
             string indexValue;
             if (value is DateTimeOffset)
             {
-                indexValue = ((DateTimeOffset)value).UtcTicks.ToString(CultureInfo.InvariantCulture);
+                indexValue = ((DateTimeOffset) value).UtcTicks.ToString(CultureInfo.InvariantCulture);
             }
             else if (value is DateTime)
             {
-                indexValue = ((DateTime)value).Ticks.ToString(CultureInfo.InvariantCulture);
+                indexValue = ((DateTime) value).Ticks.ToString(CultureInfo.InvariantCulture);
             }
             else
             {

--- a/Neo4jClient/GraphClientFactory.cs
+++ b/Neo4jClient/GraphClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Neo4jClient.Execution;
 
 namespace Neo4jClient
 {
@@ -20,6 +21,15 @@ namespace Neo4jClient
                 _configuration.RootUri,
                 _configuration.Username,
                 _configuration.Password);
+
+            client.Connect(_configuration);
+
+            return client;
+        }
+
+        public IGraphClient Create(IHttpClient httpClient)
+        {
+            var client = new GraphClient(_configuration.RootUri, httpClient);
 
             client.Connect(_configuration);
 

--- a/Neo4jClient/GraphClientFactory.cs
+++ b/Neo4jClient/GraphClientFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace Neo4jClient
+﻿using System;
+
+namespace Neo4jClient
 {
     public class GraphClientFactory : IGraphClientFactory
     {
@@ -6,6 +8,12 @@
 
         public GraphClientFactory(NeoServerConfiguration configuration)
         {
+            if (_configuration == null)
+             throw new ArgumentNullException("configuration", "Neo server configuration is null");
+
+            if (configuration.ApiConfig == null)
+                throw new ArgumentException("Root Api configuration is not defined", "ApiConfig");
+
             _configuration = configuration;
         }
 

--- a/Neo4jClient/GraphClientFactory.cs
+++ b/Neo4jClient/GraphClientFactory.cs
@@ -8,11 +8,8 @@ namespace Neo4jClient
 
         public GraphClientFactory(NeoServerConfiguration configuration)
         {
-            if (_configuration == null)
+            if (configuration == null)
              throw new ArgumentNullException("configuration", "Neo server configuration is null");
-
-            if (configuration.ApiConfig == null)
-                throw new ArgumentException("Root Api configuration is not defined", "ApiConfig");
 
             _configuration = configuration;
         }

--- a/Neo4jClient/GraphClientFactory.cs
+++ b/Neo4jClient/GraphClientFactory.cs
@@ -1,0 +1,24 @@
+﻿namespace Neo4jClient
+{
+    public class GraphClientFactory : IGraphClientFactory
+    {
+        private readonly NeoServerConfiguration _configuration;
+
+        public GraphClientFactory(NeoServerConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public IGraphClient Create()
+        {
+            var client = new GraphClient(
+                _configuration.RootUri,
+                _configuration.Username,
+                _configuration.Password);
+
+            client.Connect(_configuration);
+
+            return client;
+        }
+    }
+}

--- a/Neo4jClient/IGraphClient.cs
+++ b/Neo4jClient/IGraphClient.cs
@@ -141,7 +141,7 @@ namespace Neo4jClient
 
         bool IsConnected { get; }
 
-        void Connect();
+        void Connect(NeoServerConfiguration configuration = null);
 
         List<JsonConverter> JsonConverters { get; }
         DefaultContractResolver JsonContractResolver { get; set; }

--- a/Neo4jClient/IGraphClient.cs
+++ b/Neo4jClient/IGraphClient.cs
@@ -11,7 +11,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Neo4jClient
 {
-    public interface IGraphClient : ICypherGraphClient
+    public interface IGraphClient : ICypherGraphClient, IDisposable
     {
         [Obsolete("The concept of a single root node has being dropped in Neo4j 2.0. Use an alternate strategy for having known reference points in the graph, such as labels.")]
         RootNode RootNode { get; }

--- a/Neo4jClient/IGraphClientFactory.cs
+++ b/Neo4jClient/IGraphClientFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Neo4jClient
+{
+    public interface IGraphClientFactory
+    {
+        IGraphClient Create();
+    }
+}

--- a/Neo4jClient/IGraphClientFactory.cs
+++ b/Neo4jClient/IGraphClientFactory.cs
@@ -1,7 +1,10 @@
-﻿namespace Neo4jClient
+﻿using Neo4jClient.Execution;
+
+namespace Neo4jClient
 {
     public interface IGraphClientFactory
     {
         IGraphClient Create();
+        IGraphClient Create(IHttpClient client);
     }
 }

--- a/Neo4jClient/Neo4jClient.csproj
+++ b/Neo4jClient/Neo4jClient.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Execution\IExecutionPolicyFactory.cs" />
     <Compile Include="Execution\IHttpClient.cs" />
     <Compile Include="Extensions\MemberInfoExtensions.cs" />
+    <Compile Include="GraphClientFactory.cs" />
     <Compile Include="ICypherGraphClient.cs" />
     <Compile Include="Execution\IRequestTypeBuilder.cs" />
     <Compile Include="Execution\IRequestWithPendingContentBuilder.cs" />
@@ -125,6 +126,7 @@
     <Compile Include="Execution\ResponseFailBuilder.cs" />
     <Compile Include="Execution\ResponseFailBuilder`TParse.cs" />
     <Compile Include="Execution\RestExecutionPolicy.cs" />
+    <Compile Include="IGraphClientFactory.cs" />
     <Compile Include="NeoException.cs" />
     <Compile Include="NeoServerConfiguration.cs" />
     <Compile Include="Serialization\DeserializationContext.cs" />

--- a/Neo4jClient/Neo4jClient.csproj
+++ b/Neo4jClient/Neo4jClient.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Execution\ResponseFailBuilder`TParse.cs" />
     <Compile Include="Execution\RestExecutionPolicy.cs" />
     <Compile Include="NeoException.cs" />
+    <Compile Include="NeoServerConfiguration.cs" />
     <Compile Include="Serialization\DeserializationContext.cs" />
     <Compile Include="HttpClient.cs" />
     <Compile Include="HttpContentExtensions.cs" />

--- a/Neo4jClient/NeoServerConfiguration.cs
+++ b/Neo4jClient/NeoServerConfiguration.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Net;
+using Neo4jClient.ApiModels;
+using Neo4jClient.Execution;
+
+namespace Neo4jClient
+{
+    public class NeoServerConfiguration
+    {
+        internal RootApiResponse ApiConfig { get; set; }
+
+        private NeoServerConfiguration(RootApiResponse apiConfig)
+        {
+            ApiConfig = apiConfig;
+        }
+
+        public static NeoServerConfiguration GetConfiguration(Uri rootUri, string username = null, string password = null)
+        {
+            return GetConfiguration(rootUri, username, password, null);
+        }
+
+        internal static NeoServerConfiguration GetConfiguration(Uri rootUri, string username, string password, ExecutionConfiguration executionConfiguration)
+        {
+            if (executionConfiguration == null)
+            {
+                var httpClient = new HttpClientWrapper(username, password);
+
+                executionConfiguration = new ExecutionConfiguration
+                {
+                    HttpClient = httpClient,
+                    UserAgent =
+                        string.Format("Neo4jClient/{0}", typeof (NeoServerConfiguration).Assembly.GetName().Version),
+                    UseJsonStreaming = true,
+                    JsonConverters = GraphClient.DefaultJsonConverters,
+                    Username = username,
+                    Password = password
+                };
+            }
+
+            if (!rootUri.AbsoluteUri.EndsWith("/"))
+                rootUri = new Uri(rootUri.AbsoluteUri + "/");
+
+            rootUri = new Uri(rootUri, "");
+
+            var result = Request.With(executionConfiguration)
+                .Get(rootUri)
+                .WithExpectedStatusCodes(HttpStatusCode.OK)
+                .ParseAs<RootApiResponse>()
+                .Execute();
+
+            var rootUriWithoutUserInfo = rootUri;
+            if (!string.IsNullOrEmpty(rootUriWithoutUserInfo.UserInfo))
+            {
+                rootUriWithoutUserInfo = new UriBuilder(rootUri.AbsoluteUri)
+                {
+                    UserName = "",
+                    Password = ""
+                }.Uri;
+            }
+
+            var baseUriLengthToTrim = rootUriWithoutUserInfo.AbsoluteUri.Length - 1;
+
+            result.Batch = result.Batch.Substring(baseUriLengthToTrim);
+            result.Node = result.Node.Substring(baseUriLengthToTrim);
+            result.NodeIndex = result.NodeIndex.Substring(baseUriLengthToTrim);
+            result.Relationship = "/relationship"; //Doesn't come in on the Service Root
+            result.RelationshipIndex = result.RelationshipIndex.Substring(baseUriLengthToTrim);
+            result.ExtensionsInfo = result.ExtensionsInfo.Substring(baseUriLengthToTrim);
+
+            if (!string.IsNullOrEmpty(result.Transaction))
+            {
+                result.Transaction = result.Transaction.Substring(baseUriLengthToTrim);
+            }
+
+            if (result.Extensions != null && result.Extensions.GremlinPlugin != null)
+            {
+                result.Extensions.GremlinPlugin.ExecuteScript =
+                    result.Extensions.GremlinPlugin.ExecuteScript.Substring(baseUriLengthToTrim);
+            }
+
+            if (result.Cypher != null)
+            {
+                result.Cypher = result.Cypher.Substring(baseUriLengthToTrim);
+            }
+
+            return new NeoServerConfiguration(result);
+        }
+    }
+}

--- a/Neo4jClient/NeoServerConfiguration.cs
+++ b/Neo4jClient/NeoServerConfiguration.cs
@@ -7,12 +7,12 @@ namespace Neo4jClient
 {
     public class NeoServerConfiguration
     {
-        internal RootApiResponse ApiConfig { get; set; }
+        internal RootApiResponse ApiConfig { get; private set; }
 
-        internal Uri RootUri { get; set; }
+        internal Uri RootUri { get; private set; }
 
-        internal string Username { get; set; }
-        internal string Password { get; set; }
+        internal string Username { get; private set; }
+        internal string Password { get; private set; }
 
         private NeoServerConfiguration(RootApiResponse apiConfig)
         {
@@ -52,6 +52,11 @@ namespace Neo4jClient
                 .WithExpectedStatusCodes(HttpStatusCode.OK)
                 .ParseAs<RootApiResponse>()
                 .Execute();
+
+            if (result == null)
+            {
+                throw new ApplicationException("Couldn't obtain server Root API configuration.");
+            }
 
             var rootUriWithoutUserInfo = rootUri;
             if (!string.IsNullOrEmpty(rootUriWithoutUserInfo.UserInfo))

--- a/Neo4jClient/NeoServerConfiguration.cs
+++ b/Neo4jClient/NeoServerConfiguration.cs
@@ -9,6 +9,11 @@ namespace Neo4jClient
     {
         internal RootApiResponse ApiConfig { get; set; }
 
+        internal Uri RootUri { get; set; }
+
+        internal string Username { get; set; }
+        internal string Password { get; set; }
+
         private NeoServerConfiguration(RootApiResponse apiConfig)
         {
             ApiConfig = apiConfig;
@@ -83,7 +88,12 @@ namespace Neo4jClient
                 result.Cypher = result.Cypher.Substring(baseUriLengthToTrim);
             }
 
-            return new NeoServerConfiguration(result);
+            return new NeoServerConfiguration(result)
+            {
+                RootUri = rootUri,
+                Username = username,
+                Password = password
+            };
         }
     }
 }


### PR DESCRIPTION
`GraphClient.Connect()` takes optional `NeoServerConfiguration` configuration object now.

The idea behind is to be able to create one single configuration object and have client per request
instead of having one single client per application. Having client per request eliminates current issues with concurrent transactions over single shared client.

**USAGE**

Composition root (structuremap example).

```
public void Register()
{
    this.For<NeoServerConfiguration>()
        .Use(() => NeoServerConfiguration.GetConfiguration(uri, user, pwd))
        .Singleton();

    this.For<IGraphClientFactory>()
        .Use<GraphClientFactory>()
        .Singleton();
}
```

Service level.

```
public class NeoServiceClass
{
    private readonly IGraphClientFactory factory;
    ...
    public async Task ExecuteQueryAsync()
    {
        using (var client = factory.Create())
        {
            // query body
        }
    }
}
```