### PR TITLE
Load csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ packages
 *.ncrunchsolution
 *.Cache
 *.vs\
+*.ghostdoc.xml

--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryLoadCsvTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryLoadCsvTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Neo4jClient.Cypher;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Neo4jClient.Test.Cypher
+{
+    /// <summary>
+    ///     Tests for the LOAD CSV command
+    /// </summary>
+    [TestFixture]
+    public class CypherFluentQueryLoadCsvTests
+    {
+        [Test]
+        public void TestLoadCsvConstruction()
+        {
+            const string expected = "LOAD CSV FROM 'file://localhost/c:/foo/bar.csv' AS row";
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .LoadCsv(new Uri("file://localhost/c:/foo/bar.csv"), "row")
+                .Query;
+
+            Assert.AreEqual(expected, query.QueryText);
+        }
+
+        [Test]
+        public void TestLoadCsvAfterWithTResultVariant()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .With(n => new {n})
+                .LoadCsv(new Uri("file://localhost/c:/foo/bar.csv"), "row")
+                .Query;
+
+            Assert.AreEqual("WITH n\r\nLOAD CSV FROM 'file://localhost/c:/foo/bar.csv' AS row", query.QueryText);
+        }
+
+
+        [Test]
+        public void ThrowsExceptionWhenUriIsNull()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client);
+
+            Assert.Throws<ArgumentException>(() => query.LoadCsv(null, "row"));
+        }
+    }
+}

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Cypher\CypherFluentQueryMatchTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryRemoveTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryPlannerTests.cs" />
+    <Compile Include="Cypher\CypherFluentQueryLoadCsvTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryUnwindTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryUsingIndexTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryWithParamTests.cs" />

--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -320,6 +320,14 @@ namespace Neo4jClient.Cypher
             return Mutate(w => w.AppendClause("FOREACH " + text));
         }
 
+        public ICypherFluentQuery LoadCsv(Uri fileUri, string identifier)
+        {
+            if(fileUri == null)
+                throw new ArgumentException("File URI must be supplied.", "fileUri");
+
+            return Mutate(w => w.AppendClause(string.Format("LOAD CSV FROM '{0}' AS {1}", fileUri.AbsoluteUri, identifier)));
+        }
+
         public ICypherFluentQuery Unwind(string collectionName, string columnName)
         {
             return Mutate(w => w.AppendClause(string.Format("UNWIND {0} AS {1}", collectionName, columnName)));

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -68,6 +68,13 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery Set(string setText);
         ICypherFluentQuery Remove(string removeText);
         ICypherFluentQuery ForEach(string text);
+
+        /// <summary>Load a CSV into Neo4j.</summary>
+        /// <remarks>This creates the following: <c>LOAD CSV FROM 'fileUri' AS identifier</c></remarks>
+        /// <param name="fileUri">The file URI in the format: <c>c:\\example.csv.</c></param>
+        /// <param name="identifier">The identifier to use in the rest of the query.</param>
+        /// <returns>An <see cref="ICypherFluentQuery"/> instance to continue the query with.</returns>
+        ICypherFluentQuery LoadCsv(Uri fileUri, string identifier);
         ICypherFluentQuery Unwind(string collection, string columnName);
         ICypherFluentQuery Unwind(IEnumerable collection, string identity);
         ICypherFluentQuery Union();

--- a/Neo4jClient/GraphClient.cs
+++ b/Neo4jClient/GraphClient.cs
@@ -1026,6 +1026,7 @@ namespace Neo4jClient
                 if (ex.TryUnwrap(out unwrappedException))
                 {
                     context.Complete(query, unwrappedException);
+
                     throw unwrappedException;
                 }
 


### PR DESCRIPTION
Adds the ability to do `LOAD CSV` without needing to go to the `IRawGraphClient` interface.

Usage:

```
client.Cypher
    .LoadCsv(new Uri("c:\\foo\\bar.csv"), row)
    .Merge("(f:Foo {Name: row[0]})
    .ExecuteWithoutResults();
```