### PR TITLE
Expose low level return distinct api

### DIFF
--- a/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
@@ -45,6 +45,16 @@ namespace Neo4jClient.Cypher
             throw new NotSupportedException("This was an internal that never should have been exposed. If you want to create a projection, you should be using the lambda overload instead. See the 'Using Functions in Return Clauses' and 'Using Custom Text in Return Clauses' sections of https://bitbucket.org/Readify/neo4jclient/wiki/cypher for details of how to do this.");
         }
 
+        public ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression expression)
+        {
+            return Mutate<TResult>(w =>
+            {
+                w.ResultMode = expression.ResultMode;
+                w.ResultFormat = expression.ResultFormat;
+                w.AppendClause("RETURN distinct " + expression.Text);
+            });
+        }
+
         public ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity)
         {
             return Mutate<TResult>(w => w.AppendClause("RETURN distinct " + identity));
@@ -65,13 +75,7 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(LambdaExpression expression)
         {
             var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, CamelCaseProperties);
-
-            return Mutate<TResult>(w =>
-            {
-                w.ResultMode = returnExpression.ResultMode;
-                w.ResultFormat = returnExpression.ResultFormat;
-                w.AppendClause("RETURN distinct " + returnExpression.Text);
-            });
+            return ReturnDistinct<TResult>(returnExpression);
         }
 
         public ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<TResult>> expression)

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -105,7 +105,15 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);
 
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity);
-//        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<TResult>> expression);
+
+        /// <summary>
+        /// Used to control deserialization when building libraries on top of Neo4jClient
+        /// </summary>
+        /// <typeparam name="TResult">The type to be returned</typeparam>
+        /// <param name="expression">The return expression</param>
+        /// <returns></returns>
+        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression expression);
+        //        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);


### PR DESCRIPTION
When developing libraries on top of Neo4jClient it can be useful to
expose the low level API to allow control over the return statement
without having to dynamically build up expression trees