### PR TITLE
Expose low level return distinct api

### DIFF
--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryAdvancedTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryAdvancedTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Neo4jClient.Cypher;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Neo4jClient.Test.Cypher
+{
+    [TestFixture]
+    public class CypherFluentQueryAdvancedTests
+    {
+        [Test]
+        public void ReturnColumnAlias()
+        {
+            // http://docs.neo4j.org/chunked/1.6/query-return.html#return-column-alias
+            // START a=node(1)
+            // RETURN a.Age AS SomethingTotallyDifferent
+
+            var client = Substitute.For<IRawGraphClient>();
+
+            client
+                .ExecuteGetCypherResults<ReturnPropertyQueryResult>(Arg.Any<CypherQuery>())
+                .Returns(Enumerable.Empty<ReturnPropertyQueryResult>());
+
+            var cypher = new CypherFluentQuery(client);
+            var results = cypher
+                .Start("a", (NodeReference) 1)
+                .Advanced.Return<ReturnPropertyQueryResult>(new ReturnExpression
+                {
+                    ResultFormat = CypherResultFormat.DependsOnEnvironment,
+                    ResultMode = CypherResultMode.Projection,
+                    Text = "a.Age AS SomethingTotallyDifferent"
+                });
+            Assert.AreEqual("START a=node(1)\r\nRETURN a.Age AS SomethingTotallyDifferent", results.Query.DebugQueryText);
+            Assert.IsInstanceOf<IEnumerable<ReturnPropertyQueryResult>>(results.Results);
+        }
+
+        public class ReturnPropertyQueryResult
+        {
+            public int SomethingTotallyDifferent { get; set; }
+        }
+    }
+}

--- a/Neo4jClient.Tests/Cypher/CypherFluentQueryResultsTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherFluentQueryResultsTests.cs
@@ -34,6 +34,7 @@ namespace Neo4jClient.Test.Cypher
             Assert.IsInstanceOf<IEnumerable<ReturnPropertyQueryResult>>(results);
         }
 
+      
         [Test]
         public void ReturnColumnAliasOfTypeEnum()
         {

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ApiModels\GremlinTableCapResponseTests.cs" />
     <Compile Include="ApiModels\RootApiResponseTests.cs" />
     <Compile Include="Cypher\AggregateTests.cs" />
+    <Compile Include="Cypher\CypherFluentQueryAdvancedTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryCustomHeaderTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryDetachDeleteTests.cs" />
     <Compile Include="Cypher\CypherFluentQueryForEachTests.cs" />

--- a/Neo4jClient/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery.cs
@@ -21,14 +21,9 @@ namespace Neo4jClient.Cypher
         protected readonly QueryWriter QueryWriter;
         protected readonly bool CamelCaseProperties;
 
-        public CypherFluentQuery(IGraphClient client)
+        public CypherFluentQuery(IGraphClient client) 
+            : this(client, new QueryWriter())
         {
-            if (!(client is IRawGraphClient))
-                throw new ArgumentException("The supplied graph client also needs to implement IRawGraphClient", "client");
-
-            Client = (IRawGraphClient)client;
-            QueryWriter = new QueryWriter();
-            CamelCaseProperties = Client.JsonContractResolver is CamelCasePropertyNamesContractResolver;
         }
 
         protected CypherFluentQuery(IGraphClient client, QueryWriter queryWriter)
@@ -39,6 +34,7 @@ namespace Neo4jClient.Cypher
             Client = (IRawGraphClient)client;
             QueryWriter = queryWriter;
             CamelCaseProperties = Client.JsonContractResolver is CamelCasePropertyNamesContractResolver;
+            Advanced = new CypherFluentQueryAdvanced(Client, QueryWriter);
         }
 
         IOrderedCypherFluentQuery MutateOrdered(Action<QueryWriter> callback)
@@ -400,6 +396,8 @@ namespace Neo4jClient.Cypher
         {
             return Client.ExecuteCypherAsync(Query);
         }
+
+        public ICypherFluentQueryAdvanced Advanced { get; private set; }
 
         IGraphClient IAttachedReference.Client
         {

--- a/Neo4jClient/Cypher/CypherFluentQueryAdvanced.cs
+++ b/Neo4jClient/Cypher/CypherFluentQueryAdvanced.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Neo4jClient.Cypher
+{
+    public class CypherFluentQueryAdvanced : ICypherFluentQueryAdvanced
+    {
+        private readonly IGraphClient client;
+        private readonly QueryWriter queryWriter;
+
+        public CypherFluentQueryAdvanced(IGraphClient client, QueryWriter queryWriter)
+        {
+            this.client = client;
+            this.queryWriter = queryWriter;
+        }
+
+        public ICypherFluentQuery<TResult> Return<TResult>(ReturnExpression returnExpression)
+        {
+            return Mutate<TResult>(w =>
+            {
+                w.ResultMode = returnExpression.ResultMode;
+                w.ResultFormat = returnExpression.ResultFormat;
+                w.AppendClause("RETURN " + returnExpression.Text);
+            });
+        }
+
+        public ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression returnExpression)
+        {
+            return Mutate<TResult>(w =>
+            {
+                w.ResultMode = returnExpression.ResultMode;
+                w.ResultFormat = returnExpression.ResultFormat;
+                w.AppendClause("RETURN distinct " + returnExpression.Text);
+            });
+        }
+        
+        protected ICypherFluentQuery<TResult> Mutate<TResult>(Action<QueryWriter> callback)
+        {
+            var newWriter = queryWriter.Clone();
+            callback(newWriter);
+            return new CypherFluentQuery<TResult>(client, newWriter);
+        }
+    }
+}

--- a/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
@@ -45,6 +45,16 @@ namespace Neo4jClient.Cypher
             throw new NotSupportedException("This was an internal that never should have been exposed. If you want to create a projection, you should be using the lambda overload instead. See the 'Using Functions in Return Clauses' and 'Using Custom Text in Return Clauses' sections of https://bitbucket.org/Readify/neo4jclient/wiki/cypher for details of how to do this.");
         }
 
+        public ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression expression)
+        {
+            return Mutate<TResult>(w =>
+            {
+                w.ResultMode = expression.ResultMode;
+                w.ResultFormat = expression.ResultFormat;
+                w.AppendClause("RETURN distinct " + expression.Text);
+            });
+        }
+
         public ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity)
         {
             return Mutate<TResult>(w => w.AppendClause("RETURN distinct " + identity));
@@ -65,13 +75,7 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(LambdaExpression expression)
         {
             var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, CamelCaseProperties);
-
-            return Mutate<TResult>(w =>
-            {
-                w.ResultMode = returnExpression.ResultMode;
-                w.ResultFormat = returnExpression.ResultFormat;
-                w.AppendClause("RETURN distinct " + returnExpression.Text);
-            });
+            return ReturnDistinct<TResult>(returnExpression);
         }
 
         public ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<TResult>> expression)

--- a/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq.Expressions;
-using Microsoft.SqlServer.Server;
 
 namespace Neo4jClient.Cypher
 {
@@ -53,25 +52,13 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> Return<TResult>(LambdaExpression expression)
         {
             var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, CamelCaseProperties);
-
-            return Mutate<TResult>(w =>
-            {
-                w.ResultMode = returnExpression.ResultMode;
-                w.ResultFormat = returnExpression.ResultFormat;
-                w.AppendClause("RETURN " + returnExpression.Text);
-            });
+            return Advanced.Return<TResult>(returnExpression);
         }
 
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(LambdaExpression expression)
         {
             var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, CamelCaseProperties);
-
-            return Mutate<TResult>(w =>
-            {
-                w.ResultMode = returnExpression.ResultMode;
-                w.ResultFormat = returnExpression.ResultFormat;
-                w.AppendClause("RETURN distinct " + returnExpression.Text);
-            });
+            return Advanced.ReturnDistinct<TResult>(returnExpression);
         }
 
         public ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<TResult>> expression)

--- a/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
+++ b/Neo4jClient/Cypher/CypherFluentQuery`Return.cs
@@ -45,16 +45,6 @@ namespace Neo4jClient.Cypher
             throw new NotSupportedException("This was an internal that never should have been exposed. If you want to create a projection, you should be using the lambda overload instead. See the 'Using Functions in Return Clauses' and 'Using Custom Text in Return Clauses' sections of https://bitbucket.org/Readify/neo4jclient/wiki/cypher for details of how to do this.");
         }
 
-        public ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression expression)
-        {
-            return Mutate<TResult>(w =>
-            {
-                w.ResultMode = expression.ResultMode;
-                w.ResultFormat = expression.ResultFormat;
-                w.AppendClause("RETURN distinct " + expression.Text);
-            });
-        }
-
         public ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity)
         {
             return Mutate<TResult>(w => w.AppendClause("RETURN distinct " + identity));
@@ -75,7 +65,13 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(LambdaExpression expression)
         {
             var returnExpression = CypherReturnExpressionBuilder.BuildText(expression, Client.CypherCapabilities, Client.JsonConverters, CamelCaseProperties);
-            return ReturnDistinct<TResult>(returnExpression);
+
+            return Mutate<TResult>(w =>
+            {
+                w.ResultMode = returnExpression.ResultMode;
+                w.ResultFormat = returnExpression.ResultFormat;
+                w.AppendClause("RETURN distinct " + returnExpression.Text);
+            });
         }
 
         public ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<TResult>> expression)

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -105,15 +105,7 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);
 
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity);
-
-        /// <summary>
-        /// Used to control deserialization when building libraries on top of Neo4jClient
-        /// </summary>
-        /// <typeparam name="TResult">The type to be returned</typeparam>
-        /// <param name="expression">The return expression</param>
-        /// <returns></returns>
-        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression expression);
-        //        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<TResult>> expression);
+//        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -13,6 +13,8 @@ namespace Neo4jClient.Cypher
         void ExecuteWithoutResults();
         Task ExecuteWithoutResultsAsync();
 
+        ICypherFluentQueryAdvanced Advanced { get; }
+
         ICypherFluentQuery WithParam(string key, object value);
         ICypherFluentQuery WithParams(IDictionary<string,object> parameters);
         ICypherFluentQuery WithParams(object parameters);

--- a/Neo4jClient/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQuery.cs
@@ -105,7 +105,15 @@ namespace Neo4jClient.Cypher
         ICypherFluentQuery<TResult> Return<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);
 
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(string identity);
-//        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<TResult>> expression);
+
+        /// <summary>
+        /// Used to control deserialization when building libraries on top of Neo4jClient
+        /// </summary>
+        /// <typeparam name="TResult">The type to be returned</typeparam>
+        /// <param name="expression">The return expression</param>
+        /// <returns></returns>
+        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression expression);
+        //        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, TResult>> expression);
         ICypherFluentQuery<TResult> ReturnDistinct<TResult>(Expression<Func<ICypherResultItem, ICypherResultItem, ICypherResultItem, TResult>> expression);

--- a/Neo4jClient/Cypher/ICypherFluentQueryAdvanced.cs
+++ b/Neo4jClient/Cypher/ICypherFluentQueryAdvanced.cs
@@ -1,0 +1,12 @@
+﻿namespace Neo4jClient.Cypher
+{
+    /// <summary>
+    /// Exposes low level return api to allow more control when developing libraries on top of Neo4jClient
+    /// </summary>
+    public interface ICypherFluentQueryAdvanced
+    {
+        ICypherFluentQuery<TResult> Return<TResult>(ReturnExpression returnExpression);
+
+        ICypherFluentQuery<TResult> ReturnDistinct<TResult>(ReturnExpression returnExpression);
+    }
+}

--- a/Neo4jClient/Neo4jClient.csproj
+++ b/Neo4jClient/Neo4jClient.csproj
@@ -74,10 +74,12 @@
     <Compile Include="ApiModels\Gremlin\GremlinTableCapResponse.cs" />
     <Compile Include="CypherPartialResult.cs" />
     <Compile Include="Cypher\All.cs" />
+    <Compile Include="Cypher\CypherFluentQueryAdvanced.cs" />
     <Compile Include="Cypher\CypherCapabilities.cs" />
     <Compile Include="Cypher\CypherFluentQuery`With.cs" />
     <Compile Include="Cypher\CypherPlanner.cs" />
     <Compile Include="Cypher\CypherWithExpressionBuilder.cs" />
+    <Compile Include="Cypher\ICypherFluentQueryAdvanced.cs" />
     <Compile Include="Cypher\ICypherFluentQuery`Where.cs" />
     <Compile Include="Cypher\ICypherFluentQuery`With.cs" />
     <Compile Include="Cypher\IFluentCypherResultItem.cs" />


### PR DESCRIPTION
When developing libraries on top of Neo4jClient it can be useful to
expose the low level API to allow control over the return statement
without having to dynamically build up expression trees