### PR TITLE
allow user to set resource manager id

### DIFF
--- a/Neo4jClient.Full/Transactions/Neo4jTransactionResourceManager.cs
+++ b/Neo4jClient.Full/Transactions/Neo4jTransactionResourceManager.cs
@@ -11,7 +11,6 @@ namespace Neo4jClient.Transactions
     /// </summary>
     internal class Neo4jTransationSinglePhaseNotification : ISinglePhaseNotification
     {
-        private static readonly Guid TransactionResourceId = new Guid("{BB792575-FAA7-4C72-A6B1-A69876CC3E1E}");
         private ITransactionExecutionEnvironment _transactionExecutionEnvironment;
 
         public Neo4jTransationSinglePhaseNotification(ITransactionExecutionEnvironment transactionExecutionEnvironment)
@@ -71,7 +70,7 @@ namespace Neo4jClient.Transactions
 
         public void Enlist(Transaction tx)
         {
-            tx.EnlistDurable(TransactionResourceId, this, EnlistmentOptions.None);
+            tx.EnlistDurable(_transactionExecutionEnvironment.ResourceManagerId, this, EnlistmentOptions.None);
         }
     }
 

--- a/Neo4jClient.Full/Transactions/TransactionExecutionEnvironment.cs
+++ b/Neo4jClient.Full/Transactions/TransactionExecutionEnvironment.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Neo4jClient.Execution;
-using Neo4jClient.Serialization;
 using Newtonsoft.Json;
 
 namespace Neo4jClient.Transactions
@@ -19,6 +18,7 @@ namespace Neo4jClient.Transactions
         public IEnumerable<JsonConverter> JsonConverters { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public Guid ResourceManagerId { get; set; }
 
         public TransactionExecutionEnvironment(ExecutionConfiguration executionConfiguration)
         {
@@ -27,6 +27,7 @@ namespace Neo4jClient.Transactions
             Username = executionConfiguration.Username;
             Password = executionConfiguration.Password;
             JsonConverters = executionConfiguration.JsonConverters;
+            ResourceManagerId = executionConfiguration.ResourceManagerId;
         }
 
     }

--- a/Neo4jClient.Shared/Execution/ExecutionConfiguration.cs
+++ b/Neo4jClient.Shared/Execution/ExecutionConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -5,6 +6,11 @@ namespace Neo4jClient.Execution
 {
     public class ExecutionConfiguration
     {
+        public ExecutionConfiguration()
+        {
+            ResourceManagerId = new Guid("{BB792575-FAA7-4C72-A6B1-A69876CC3E1E}");
+        }
+
         public IHttpClient HttpClient { get; set; }
         public bool UseJsonStreaming { get; set; }
         public string UserAgent { get; set; }
@@ -12,5 +18,6 @@ namespace Neo4jClient.Execution
         public string Username { get; set; }
         public string Password { get; set; }
         public bool HasErrors { get; set; }
+        public Guid ResourceManagerId { get; set; }
     }
 }

--- a/Neo4jClient.Shared/Transactions/ITransactionExecutionEnvironment.cs
+++ b/Neo4jClient.Shared/Transactions/ITransactionExecutionEnvironment.cs
@@ -13,5 +13,6 @@ namespace Neo4jClient.Transactions
         IEnumerable<JsonConverter> JsonConverters { get; set; }
         string Username { get; set; }
         string Password { get; set; }
+        Guid ResourceManagerId { get; set; }
     }
 }

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Serialization\UserSuppliedSerializationTests.cs" />
     <Compile Include="Transactions\Neo4jTransactionResourceManagerTests.cs" />
     <Compile Include="Transactions\QueriesInTransactionTests.cs" />
+    <Compile Include="Transactions\TransactionExecutionEnvironmentTests.cs" />
     <Compile Include="Transactions\TransactionRestResponseHelper.cs" />
     <Compile Include="Transactions\RestCallScenarioTests.cs" />
     <Compile Include="Transactions\TransactionManagementTests.cs" />

--- a/Neo4jClient.Tests/Transactions/TransactionExecutionEnvironmentTests.cs
+++ b/Neo4jClient.Tests/Transactions/TransactionExecutionEnvironmentTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Neo4jClient.Execution;
+using Neo4jClient.Transactions;
+using NUnit.Framework;
+
+namespace Neo4jClient.Test.Transactions
+{
+    [TestFixture]
+    public class TransactionExecutionEnvironmentTests
+    {
+        [Test]
+        public void ResourceManagerIdDefaultValueIsSet()
+        {
+            var configuration = new ExecutionConfiguration();
+            var executionEnvironment = new TransactionExecutionEnvironment(configuration);
+            Assert.AreEqual(configuration.ResourceManagerId, executionEnvironment.ResourceManagerId);
+        }
+
+        [Test]
+        public void UserCanSetResourceManagerId()
+        {
+            var resourceManagerId = Guid.NewGuid();
+            var configuration = new ExecutionConfiguration {ResourceManagerId = resourceManagerId};
+            var executionEnvironment = new TransactionExecutionEnvironment(configuration);
+            Assert.AreEqual(resourceManagerId, executionEnvironment.ResourceManagerId);
+        }
+    }
+}


### PR DESCRIPTION
When there are multiple instances of the graph client library running in
different procesess transactions will not be able to register on account
of the same resource manager id being used. Allowing the user to set the
resource manager id will prevent this problem.