### PR TITLE
Use EXISTS() instead of HAS() for 3.0

### DIFF
--- a/Neo4jClient.Shared/Cypher/CypherCapabilities.cs
+++ b/Neo4jClient.Shared/Cypher/CypherCapabilities.cs
@@ -23,12 +23,17 @@ namespace Neo4jClient.Cypher
         {
             SupportsPropertySuffixesForControllingNullComparisons = false,
             SupportsNullComparisonsWithIsOperator = false,
+            SupportsHasFunction = true
         };
 
         public static readonly CypherCapabilities Cypher22 = new CypherCapabilities(Cypher20){SupportsPlanner = true};
         public static readonly CypherCapabilities Cypher226 = new CypherCapabilities(Cypher22) { AutoRollsBackOnError = true };
         public static readonly CypherCapabilities Cypher23 = new CypherCapabilities(Cypher226) {SupportsStartsWith = true};
-        public static readonly CypherCapabilities Cypher30 = new CypherCapabilities(Cypher23) {SupportsStoredProcedures = true};
+        public static readonly CypherCapabilities Cypher30 = new CypherCapabilities(Cypher23)
+        {
+            SupportsStoredProcedures = true,
+            SupportsHasFunction = false
+        };
         public static readonly CypherCapabilities Default = Cypher20;
 
         public bool SupportsPlanner { get; set; }
@@ -42,5 +47,10 @@ namespace Neo4jClient.Cypher
         public bool SupportsStoredProcedures { get; set; }
 
         public bool AutoRollsBackOnError { get; set; }
+
+        /// <summary>
+        /// Cypher 3.0 no longer has the HAS() function, as it has been now superseded by EXISTS()
+        /// </summary>
+        public bool SupportsHasFunction { get; set; }
     }
 }

--- a/Neo4jClient.Shared/Cypher/CypherWhereExpressionVisitor.cs
+++ b/Neo4jClient.Shared/Cypher/CypherWhereExpressionVisitor.cs
@@ -117,10 +117,15 @@ namespace Neo4jClient.Cypher
                 {
                     TextOutput.Append(" is not null");
                 }
-                else
+                else if (capabilities.SupportsHasFunction)
                 {
                     TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
                     TextOutput.Append(string.Format("has({0})", lastWrittenMemberName));
+                }
+                else
+                {
+                    TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
+                    TextOutput.Append(string.Format("exists({0})", lastWrittenMemberName));
                 }
                 return node;
             }
@@ -132,10 +137,15 @@ namespace Neo4jClient.Cypher
                 {
                     TextOutput.Append(" is null");
                 }
-                else
+                else if (capabilities.SupportsHasFunction)
                 {
                     TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
                     TextOutput.Append(string.Format("not(has({0}))", lastWrittenMemberName));
+                }
+                else
+                {
+                    TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
+                    TextOutput.Append(string.Format("not(exists({0}))", lastWrittenMemberName));
                 }
                 return node;
             }
@@ -264,10 +274,15 @@ namespace Neo4jClient.Cypher
                 {
                     TextOutput.Append(" is not null");
                 }
-                else
+                else if (capabilities.SupportsHasFunction)
                 {
                     TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
                     TextOutput.Append(string.Format("has({0})", lastWrittenMemberName));
+                }
+                else
+                {
+                    TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
+                    TextOutput.Append(string.Format("exists({0})", lastWrittenMemberName));
                 }
 
                 // no further processing is required
@@ -281,10 +296,15 @@ namespace Neo4jClient.Cypher
                 {
                     TextOutput.Append(" is null");
                 }
-                else
+                else if(capabilities.SupportsHasFunction)
                 {
                     TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
                     TextOutput.Append(string.Format("not(has({0}))", lastWrittenMemberName));
+                }
+                else
+                {
+                    TextOutput.Remove(TextOutput.ToString().LastIndexOf(lastWrittenMemberName, StringComparison.Ordinal), lastWrittenMemberName.Length);
+                    TextOutput.Append(string.Format("not(exists({0}))", lastWrittenMemberName));
                 }
 
                 // no further processing is required

--- a/Neo4jClient.Tests/Cypher/CypherWhereExpressionBuilderTests.cs
+++ b/Neo4jClient.Tests/Cypher/CypherWhereExpressionBuilderTests.cs
@@ -174,6 +174,21 @@ namespace Neo4jClient.Test.Cypher
         }
 
         [Test]
+        public void For30VersionsEvaluateTrueWhenComparingMissingNullablePropertyToNullProperty()
+        {
+            var parameters = new Dictionary<string, object>();
+            var fooWithNulls = new Foo
+            {
+                NullableBar = null
+            };
+            Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == fooWithNulls.NullableBar;
+
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher30);
+
+            Assert.AreEqual("(not(exists(foo.NullableBar)))", result);
+        }
+
+        [Test]
         public void For20VersionsEvaluateTrueWhenComparingMissingNullablePropertyToNullProperty()
         {
             var parameters = new Dictionary<string, object>();
@@ -201,6 +216,21 @@ namespace Neo4jClient.Test.Cypher
             var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher19);
 
             Assert.AreEqual("(foo.NullableBar? is not null)", result);
+        }
+
+        [Test]
+        public void For30VersionsEvaluateTrueWhenComparingNotMissingNullablePropertyToNullProperty()
+        {
+            var parameters = new Dictionary<string, object>();
+            var fooWithNulls = new Foo
+            {
+                NullableBar = null
+            };
+            Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != fooWithNulls.NullableBar;
+
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher30);
+
+            Assert.AreEqual("(exists(foo.NullableBar))", result);
         }
 
         [Test]
@@ -404,24 +434,48 @@ namespace Neo4jClient.Test.Cypher
 
         [Test]
         [Description("https://bitbucket.org/Readify/neo4jclient/issue/163/neo4j-v2m6-client-syntax-error")]
-        public void DontSuffixPropertyWhenComparingMissingNullablePropertyToNull()
+        public void For30DontSuffixPropertyWhenComparingMissingNullablePropertyToNull()
         {
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == null;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v));
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher30);
+
+            Assert.AreEqual("(not(exists(foo.NullableBar)))", result);
+        }
+
+        [Test]
+        [Description("https://bitbucket.org/Readify/neo4jclient/issue/163/neo4j-v2m6-client-syntax-error")]
+        public void For20DontSuffixPropertyWhenComparingMissingNullablePropertyToNull()
+        {
+            var parameters = new Dictionary<string, object>();
+            Expression<Func<Foo, bool>> expression = foo => foo.NullableBar == null;
+
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher20);
 
             Assert.AreEqual("(not(has(foo.NullableBar)))", result);
         }
 
         [Test]
         [Description("https://bitbucket.org/Readify/neo4jclient/issue/163/neo4j-v2m6-client-syntax-error")]
-        public void DontSuffixPropertyWhenComparingMissingNullablePropertyToNotNull()
+        public void For30DontSuffixPropertyWhenComparingMissingNullablePropertyToNotNull()
         {
             var parameters = new Dictionary<string, object>();
             Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != null;
 
-            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v));
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher30);
+
+            Assert.AreEqual("(exists(foo.NullableBar))", result);
+        }
+
+        [Test]
+        [Description("https://bitbucket.org/Readify/neo4jclient/issue/163/neo4j-v2m6-client-syntax-error")]
+        public void For20DontSuffixPropertyWhenComparingMissingNullablePropertyToNotNull()
+        {
+            var parameters = new Dictionary<string, object>();
+            Expression<Func<Foo, bool>> expression = foo => foo.NullableBar != null;
+
+            var result = CypherWhereExpressionBuilder.BuildText(expression, v => CreateParameter(parameters, v), CypherCapabilities.Cypher20);
 
             Assert.AreEqual("(has(foo.NullableBar))", result);
         }


### PR DESCRIPTION
HAS() was deprecated since 2.3.x, but it has been removed in 3.0. Any property comparison with a null constant was failing because Neo4jClient was generating it with HAS().

I've added a new cypher capability as well as the necessary changes in the visitors, as well as the unit tests.