### PR TITLE
Bolt Serialization/Deserialization Fixes

### DIFF
--- a/Neo4jClient.Shared/Neo4jDriverExtensions.cs
+++ b/Neo4jClient.Shared/Neo4jDriverExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Globalization;
 using Neo4j.Driver.V1;
 using Neo4jClient.Cypher;
 using Newtonsoft.Json;
@@ -11,6 +12,8 @@ namespace Neo4jClient
 {
     public static class Neo4jDriverExtensions
     {
+        private const string DefaultDateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK";
+
         public static IStatementResult Run(this ISession session, CypherQuery query, IGraphClient gc)
         {
             return session.Run(query.QueryText, query.ToNeo4jDriverParameters(gc));
@@ -78,6 +81,16 @@ namespace Neo4jClient
 
         private static object SerializePrimitive(Type type, TypeInfo typeInfo, object instance)
         {
+            if (type == typeof(DateTime))
+            {
+                return SerializeDateTime((DateTime) instance);
+            }
+
+            if (type == typeof(DateTimeOffset))
+            {
+                return SerializeDateTimeOffset((DateTimeOffset) instance);
+            }
+
             if (type == typeof(string) || typeInfo.IsPrimitive)
             {
                 return instance;
@@ -88,8 +101,20 @@ namespace Neo4jClient
                 return $"{instance}";
             }
 
+            // last case scenario serialize it as JSON
             return JsonConvert.SerializeObject(instance);
         }
+
+        private static string SerializeDateTime(DateTime dateTime)
+        {
+             return dateTime.ToString(DefaultDateTimeFormat, CultureInfo.CurrentCulture);
+        }
+
+        private static string SerializeDateTimeOffset(DateTimeOffset dateTime)
+        {
+            return dateTime.ToString(DefaultDateTimeFormat, CultureInfo.CurrentCulture);
+        }
+
 
         private static object SerializeDictionary(Type type, object value)
         {
@@ -110,15 +135,6 @@ namespace Neo4jClient
             }
 
             return serialized;
-        }
-
-        private static IEnumerable<IDictionary<string, object>> ConvertListToListOfDictionaries(IEnumerable list, IGraphClient gc)
-        {
-            var output = new List<IDictionary<string, object>>();
-            foreach (var item in list)
-                output.Add(JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(item, Formatting.None, gc.JsonConverters.ToArray())));
-
-            return output;
         }
     }
 }

--- a/Neo4jClient.Shared/Neo4jDriverExtensions.cs
+++ b/Neo4jClient.Shared/Neo4jDriverExtensions.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using Neo4j.Driver.V1;
 using Neo4jClient.Cypher;
-using Neo4jClient.Serialization;
 using Newtonsoft.Json;
 
 namespace Neo4jClient
@@ -29,47 +28,88 @@ namespace Neo4jClient
 
             foreach (var item in query.QueryParameters)
             {
-                var type = item.Value.GetType();
-                var typeInfo = type.GetTypeInfo();
+                var value = item.Value;
 
-                if (typeInfo.IsClass && type != typeof(string))
-                {
-                    object itemToAdd;
-                    if (typeInfo.ImplementedInterfaces.Contains(typeof(IEnumerable)))
-                    {
-                        if (typeInfo.IsArray)
-                        {
-                            itemToAdd = item.Value;
-                        }
-                        else if (typeInfo.IsGenericType && type.GenericTypeArguments.Length == 1)
-                        {
-                            var genericType = type.GenericTypeArguments[0];
-                            var genericTypeInfo = genericType.GetTypeInfo();
-                            if (genericTypeInfo.IsValueType || genericType == typeof(string))
-                                itemToAdd = item.Value;
-                            else
-                                itemToAdd = ConvertListToListOfDictionaries((IEnumerable) item.Value, gc);
-                        }
-
-                        else itemToAdd = ConvertListToListOfDictionaries((IEnumerable) item.Value, gc);
-                    }
-                    else
-                    {
-                        var serialized = JsonConvert.SerializeObject(item.Value, Formatting.None, gc.JsonConverters.ToArray());
-                        itemToAdd = JsonConvert.DeserializeObject<Dictionary<string, object>>(serialized, new JsonSerializerSettings{DateParseHandling = DateParseHandling.None} );
-                    }
-
-                    output.Add(item.Key, itemToAdd);
-                }
-                else if (type == typeof(string) || typeInfo.IsPrimitive)
-                    output.Add(item.Key, item.Value);
-                else if(type == typeof(Guid))
-                    output.Add(item.Key, $"{item.Value}");
-                else
-                    output.Add(item.Key, JsonConvert.SerializeObject(item.Value));
+                output.Add(item.Key, Serialize(item.Value));
             }
 
             return output;
+        }
+
+        private static object Serialize(object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            var type = value.GetType();
+            var typeInfo = type.GetTypeInfo();
+
+            if (typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+            {
+                return SerializeDictionary(type, value);
+            }
+
+            if (typeInfo.IsClass && type != typeof(string))
+            {
+                if (typeInfo.IsArray || typeInfo.ImplementedInterfaces.Contains(typeof(IEnumerable)))
+                {
+                    return SerializeCollection((IEnumerable)value);
+                }
+
+                return SerializeObject(type, value);
+            }
+
+            return SerializePrimitive(type, typeInfo, value);
+        }
+        
+        private static object SerializeObject(Type type, object value)
+        {
+            return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(pi => !(pi.GetIndexParameters().Any() || pi.IsDefined(typeof(JsonIgnoreAttribute))))
+                .ToDictionary(pi => pi.Name, pi => Serialize(pi.GetValue(value)));
+        }
+
+        private static object SerializeCollection(IEnumerable value)
+        {
+            return value.Cast<object>().Select(o => Serialize(o)).ToArray();
+        }
+
+        private static object SerializePrimitive(Type type, TypeInfo typeInfo, object instance)
+        {
+            if (type == typeof(string) || typeInfo.IsPrimitive)
+            {
+                return instance;
+            }
+
+            if (type == typeof(Guid))
+            {
+                return $"{instance}";
+            }
+
+            return JsonConvert.SerializeObject(instance);
+        }
+
+        private static object SerializeDictionary(Type type, object value)
+        {
+            var keyType = type.GetGenericArguments()[0];
+            if (keyType != typeof(string))
+            {
+                throw new NotSupportedException(
+                    $"Dictionary had keys with type '{keyType.Name}'. Only dictionaries with type '{nameof(String)}' are supported.");
+            }
+
+            var serialized = new Dictionary<string, object>();
+            foreach (var item in (dynamic) value)
+            {
+                string key = item.Key;
+                object entry = item.Value;
+
+                serialized[key] = Serialize(entry);
+            }
+
+            return serialized;
         }
 
         private static IEnumerable<IDictionary<string, object>> ConvertListToListOfDictionaries(IEnumerable list, IGraphClient gc)

--- a/Neo4jClient.Shared/StatementResultHelper.cs
+++ b/Neo4jClient.Shared/StatementResultHelper.cs
@@ -375,7 +375,6 @@ namespace Neo4jClient
                 }
                 else if (obj is IEnumerable && !(obj is string))
                 {
-                    var count = 0;
                     var listObj = ((IEnumerable) obj).Cast<object>().ToList();
 
                     var first = listObj.FirstOrDefault();
@@ -390,15 +389,17 @@ namespace Neo4jClient
                     }
                     else
                     {
+                        var parsedItems = new List<dynamic>();
                         foreach (var o in listObj)
                         {
                             var newRecord = new Neo4jClientRecord(o, identifier);
-                            var p2 = ParseAnonymousAsDynamic(newRecord, graphClient, true);
-                            inner.Add(p2);
-                            count++;
+                            // item o gets parsed and returned always as a list when onlyReturnData = true
+                            var p2 = (List<dynamic>)ParseAnonymousAsDynamic(newRecord, graphClient, true);
+                            // but we only need the first item
+                            parsedItems.Add(p2.First());
                         }
-                        if (count == 0)
-                            inner.Add(new object[0]);
+
+                        inner.Add(parsedItems);
                     }
                 }
                 else

--- a/Neo4jClient.Shared/StatementResultHelper.cs
+++ b/Neo4jClient.Shared/StatementResultHelper.cs
@@ -24,7 +24,7 @@ namespace Neo4jClient
 
             if (isNestedInList)
             {
-                inSet = true;
+                inSet = false;
                 isNested = false;
             }
 


### PR DESCRIPTION
I detected two serialization bugs for `BoltGraphClient`:
* When a `List` was to be casted into an anonymous typed object, there was a bug where the `ParseAnonymousAsDynamic()` method was splitting all the elements of such list into separate lists containing one element.
* When passing query parameters to `session.Run()` the simple JSON Serialize/Deserialize was not working because when you passed a `Dictionary<string, int[]>` it was being transformed back as `Dictionary<string, JValue>`.

For the first bug the fix is simple: just don't split the list into multiple elements.
For the second bug the fix was more complicated as it is no longer JSON serializing and deserializing but making use of the fact that the bolt driver doesn't care if it receives `object[]` or `List<int>`. So I made the code able to receive object graphs with arbitrary depth.