### PR TITLE
Backward Compatibility for ExecuteMultipleCypherQueriesInTransaction in BoltGraphClient

### DIFF
--- a/Neo4jClient.Shared/BoltGraphClient.cs
+++ b/Neo4jClient.Shared/BoltGraphClient.cs
@@ -639,36 +639,19 @@ namespace Neo4jClient
         }
 
         /// <inheritdoc />
-        
+        [Obsolete]
         void IRawGraphClient.ExecuteMultipleCypherQueriesInTransaction(IEnumerable<CypherQuery> queries, NameValueCollection customHeaders = null)
         {
-//            var context = ExecutionContext.Begin(this);
-//
-//            var queryList = queries.ToList();
-//            string queriesInText = string.Join(", ", queryList.Select(query => query.QueryText));
-//
-//            var stopwatch = new Stopwatch();
-//            stopwatch.Start();
-//
-//            var response = Request.With(ExecutionConfiguration, customHeaders)
-//                .Post(context.Policy.BaseEndpoint)
-//                .WithJsonContent(SerializeAsJson(new CypherStatementList(queryList)))
-//                .WithExpectedStatusCodes(HttpStatusCode.OK, HttpStatusCode.Created)
-//                .Execute("Executing multiple queries: " + queriesInText);
-//
-//            var transactionObject = transactionManager.CurrentNonDtcTransaction ??
-//                                    transactionManager.CurrentDtcTransaction;
-//
-//            if (customHeaders != null && customHeaders.Count > 0)
-//            {
-//                transactionObject.CustomHeaders = customHeaders;
-//            }
-//
-//            context.Policy.AfterExecution(TransactionHttpUtils.GetMetadataFromResponse(response), transactionObject);
-//            context.Complete(OperationCompleted != null ? string.Join(", ", queryList.Select(query => query.DebugQueryText)) : string.Empty);
-//            context.Policy.AfterExecution(TransactionHttpUtils.GetMetadataFromResponse(response), transactionObject);
+            using (var tx = BeginTransaction())
+            {
+                // the HTTP endpoint executed the transactions in a serial fashion
+                foreach (var query in queries)
+                {
+                    ((IRawGraphClient) this).ExecuteCypher(query);
+                }
 
-            throw new InvalidOperationException(NotValidForBolt);
+                tx.Commit();
+            }
         }
 
         /// <inheritdoc />

--- a/Neo4jClient.Tests/Transactions/BoltQueriesInTransactionTests.cs
+++ b/Neo4jClient.Tests/Transactions/BoltQueriesInTransactionTests.cs
@@ -79,6 +79,26 @@ namespace Neo4jClient.Test.Transactions
         public class TransactionGraphClientTests : IClassFixture<CultureInfoSetupFixture>
         {
             [Fact]
+            public void SimulateMultipleQueries_AsSingleTransaction()
+            {
+                ISession session;
+                IDriver driver;
+                Neo4j.Driver.V1.ITransaction transaction;
+                IGraphClient graphClient;
+
+                GetAndConnectGraphClient(out graphClient, out driver, out session, out transaction);
+
+                var query = graphClient.Cypher.Match("(n)").Set("n.Value = 'test'").Query;
+
+                var rawGraphClient = (IRawGraphClient) graphClient;
+                rawGraphClient.ExecuteMultipleCypherQueriesInTransaction(new[]{query});
+
+                driver.Received(1).Session();
+                session.Received(1).BeginTransaction();
+                transaction.Received(1).Success();
+            }
+
+            [Fact]
             public void SimpleTransaction_AsTransactionalGc_1Query()
             {
                 ISession session;


### PR DESCRIPTION
Although the reason for `ExecuteMultipleCypherQueriesInTransaction()` was to efficiently send multiple queries in a single HTTP connection/query/disconnect cycle, the recent `BoltGraphClient` marked it as an `InvalidOperationException`, this has already broken compatibility with a call I have in one business project and could potentially affect many more, while this can be easily "simulated."

The "fix" for this is just to effectively setup a transaction and cycle through the queries in such transaction. As `BeginTransaction()` will normally join an existing transaction if there's one, then the semantics remain the same. I have also marked it as `[Obsolete]` within the `BoltGraphClient`