### PR TITLE
Fix Wrong Deserialization for Complex Maps in BoltGraphClient

### DIFF
--- a/Neo4jClient.Shared/BoltGraphClient.cs
+++ b/Neo4jClient.Shared/BoltGraphClient.cs
@@ -612,7 +612,7 @@ namespace Neo4jClient
 
         private List<TResult> ParseResults<TResult>(IStatementResult result, CypherQuery query)
         {
-            var deserializer = new CypherJsonDeserializer<TResult>(this, query.ResultMode, query.ResultFormat, false);
+            var deserializer = new CypherJsonDeserializer<TResult>(this, query.ResultMode, query.ResultFormat, false, true);
             var results = new List<TResult>();
             if (typeof(TResult).IsAnonymous())
             {

--- a/Neo4jClient.Shared/Serialization/CypherJsonDeserializer.cs
+++ b/Neo4jClient.Shared/Serialization/CypherJsonDeserializer.cs
@@ -17,6 +17,7 @@ namespace Neo4jClient.Serialization
         readonly CypherResultMode resultMode;
         private readonly CypherResultFormat resultFormat;
         private readonly bool inTransaction;
+        private readonly bool inBolt;
 
         readonly CultureInfo culture = CultureInfo.InvariantCulture;
 
@@ -24,15 +25,21 @@ namespace Neo4jClient.Serialization
         public CypherJsonDeserializer() { }
 
         public CypherJsonDeserializer(IGraphClient client, CypherResultMode resultMode, CypherResultFormat resultFormat)
-            : this(client, resultMode, resultFormat, false)
+            : this(client, resultMode, resultFormat, false, false)
         {
         }
 
         public CypherJsonDeserializer(IGraphClient client, CypherResultMode resultMode, CypherResultFormat resultFormat, bool inTransaction)
+            : this(client, resultMode, resultFormat, inTransaction, false)
+        {
+        }
+
+        public CypherJsonDeserializer(IGraphClient client, CypherResultMode resultMode, CypherResultFormat resultFormat, bool inTransaction, bool inBolt)
         {
             this.client = client;
             this.resultMode = resultMode;
             this.inTransaction = inTransaction;
+            this.inBolt = inBolt;
             // here is where we decide if we should deserialize as transactional or REST endpoint data format.
             if (resultFormat == CypherResultFormat.DependsOnEnvironment)
             {
@@ -214,7 +221,7 @@ Include this raw JSON, with any sensitive values replaced with non-sensitive equ
                     return ParseInSingleColumnMode(context, resultRoot, columnNames, jsonTypeMappings.ToArray());
                 case CypherResultMode.Projection:
                     // if we are in transaction and we have an object we dont need a mutation
-                    if (!inTransaction)
+                    if (!inTransaction && !inBolt)
                     {
                         jsonTypeMappings.Add(new TypeMapping
                         {

--- a/Neo4jClient.Shared/StatementResultHelper.cs
+++ b/Neo4jClient.Shared/StatementResultHelper.cs
@@ -384,7 +384,12 @@ namespace Neo4jClient
                         dynamic expando2 = new ExpandoObject();
                         var t2 = (IDictionary<string, object>) expando2;
                         foreach (var property in newNode.Properties)
-                            t2[property.Key] = property.Value;
+                        {
+                            var parsedValue = 
+                                ParseElementInCollectionForAnonymous(graphClient, property.Value, identifier);
+                            t2[property.Key] = parsedValue;
+                        }
+
                         inner.Add(expando2);
                     }
                     else
@@ -392,11 +397,7 @@ namespace Neo4jClient
                         var parsedItems = new List<dynamic>();
                         foreach (var o in listObj)
                         {
-                            var newRecord = new Neo4jClientRecord(o, identifier);
-                            // item o gets parsed and returned always as a list when onlyReturnData = true
-                            var p2 = (List<dynamic>)ParseAnonymousAsDynamic(newRecord, graphClient, true);
-                            // but we only need the first item
-                            parsedItems.Add(p2.First());
+                            parsedItems.Add(ParseElementInCollectionForAnonymous(graphClient, o, identifier));
                         }
 
                         inner.Add(parsedItems);
@@ -427,6 +428,15 @@ namespace Neo4jClient
             };
 
             return output;
+        }
+
+        private static dynamic ParseElementInCollectionForAnonymous(IGraphClient graphClient, dynamic item, string identifier)
+        {
+            var newRecord = new Neo4jClientRecord(item, identifier);
+            // item o gets parsed and returned always as a list when onlyReturnData = true
+            var p2 = (List<dynamic>)ParseAnonymousAsDynamic(newRecord, graphClient, true);
+            // but we only need the first item
+            return p2.First();
         }
 
         public static bool IsAnonymous(this Type type)

--- a/Neo4jClient.Tests.Shared/BoltGraphClientTests/Cypher/ExecuteGetCypherResultsTests.cs
+++ b/Neo4jClient.Tests.Shared/BoltGraphClientTests/Cypher/ExecuteGetCypherResultsTests.cs
@@ -223,6 +223,86 @@ namespace Neo4jClient.Test.BoltGraphClientTests.Cypher
             }
         }
 
+        private class ObjectWithNodeWithIds
+        {
+            public ObjectWithIds Node { get; set; }
+            public int Count { get; set; }
+        }
+
+        [Fact]
+        public void ShouldDeserializeMapWithAnonymousReturn()
+        {
+            // simulates the following query
+            const string queryText = "MATCH (start:Node) WITH {Node: start, Count: 1} AS Node, start RETURN Node, start";
+
+            var cypherQuery = new CypherQuery(queryText, new Dictionary<string, object>(), CypherResultMode.Projection,
+                CypherResultFormat.Transactional);
+
+            using (var testHarness = new BoltTestHarness())
+            {
+                INode start = new TestNode
+                {
+                    Id = 1337,
+                    Properties = new Dictionary<string, object>()
+                    {
+                        {"Ids", new List<int>() {1, 2, 3}}
+                    }
+                };
+                IDictionary<string, object> resultMap = new Dictionary<string, object>()
+                {
+                    {"Node", start},
+                    {"Count", 1}
+                };
+
+                var recordMock = new Mock<IRecord>();
+                recordMock
+                    .Setup(r => r["Node"])
+                    .Returns(resultMap);
+                recordMock
+                    .Setup(r => r["Start"])
+                    .Returns(start);
+                recordMock
+                    .Setup(r => r.Keys)
+                    .Returns(new[] { "Node", "Start" });
+
+                var testStatementResult = new TestStatementResult(new[] { "Node", "Start" }, recordMock.Object);
+                testHarness.SetupCypherRequestResponse(cypherQuery.QueryText, cypherQuery.QueryParameters, testStatementResult);
+
+                // the anon type
+                var dummy = new
+                {
+                    Node = new ObjectWithNodeWithIds(),
+                    Start = new ObjectWithIds()
+                };
+                var anonType = dummy.GetType();
+                var graphClient = testHarness.CreateAndConnectBoltGraphClient();
+                var genericGetCypherResults = typeof(IRawGraphClient).GetMethod(nameof(graphClient.ExecuteGetCypherResults));
+                var anonymousGetCypherResults = genericGetCypherResults.MakeGenericMethod(anonType);
+                var genericResults = (IEnumerable)anonymousGetCypherResults.Invoke(graphClient, new object[] { cypherQuery });
+
+                var results = genericResults.Cast<object>().ToArray();
+
+                //Assert
+                Assert.Equal(1, results.Length);
+
+                var startNode = (ObjectWithIds)anonType.GetProperty(nameof(dummy.Start)).GetValue(results.First(), null);
+                startNode.Ids.Count.Should().Be(3);
+                startNode.Ids[0].Should().Be(1);
+                startNode.Ids[1].Should().Be(2);
+                startNode.Ids[2].Should().Be(3);
+
+                var nodeWrapper = (ObjectWithNodeWithIds)anonType.GetProperty(nameof(dummy.Node)).GetValue(results.First(), null);
+                nodeWrapper.Count.Should().Be(1);
+                startNode = nodeWrapper.Node;
+
+                startNode.Ids.Count.Should().Be(3);
+                startNode.Ids[0].Should().Be(1);
+                startNode.Ids[1].Should().Be(2);
+                startNode.Ids[2].Should().Be(3);
+            }
+
+        }
+
         [Fact]
         public void ShouldDeserializeCollectionsWithAnonymousReturn()
         {


### PR DESCRIPTION
Current deserialization fails for the following query:

`MATCH (start:Node) WITH {Node: start, Count: 1} AS Node, start RETURN Node, start`

That is if it includes complex data within the mapping, it fails. 

It includes unit tests.