### PR TITLE
DebugQueryText can process new $param syntax

### DIFF
--- a/Neo4jClient.Shared/Cypher/CypherQuery.cs
+++ b/Neo4jClient.Shared/Cypher/CypherQuery.cs
@@ -96,9 +96,8 @@ namespace Neo4jClient.Cypher
                         (current, paramName) =>
                         {
                             var value = queryParameters[paramName];
-                            value = serializer.Serialize(value);
-                            var paramNameSyntax = "$" + paramName;
-                            return current.Contains(paramNameSyntax) ? current.Replace(paramNameSyntax, value.ToString()) : current.Replace("{" + paramName + "}", value.ToString());
+                            value = serializer.Serialize(value);                           
+                            return current.Replace("$" + paramName, value.ToString()).Replace("{" + paramName + "}", value.ToString());
                         });
 
                 return text;

--- a/Neo4jClient.Shared/Cypher/CypherQuery.cs
+++ b/Neo4jClient.Shared/Cypher/CypherQuery.cs
@@ -97,7 +97,8 @@ namespace Neo4jClient.Cypher
                         {
                             var value = queryParameters[paramName];
                             value = serializer.Serialize(value);
-                            return current.Replace("{" + paramName + "}", value.ToString());
+                            var paramNameSyntax = "$" + paramName;
+                            return current.Contains(paramNameSyntax) ? current.Replace(paramNameSyntax, value.ToString()) : current.Replace("{" + paramName + "}", value.ToString());
                         });
 
                 return text;

--- a/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWithParamTests.cs
+++ b/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWithParamTests.cs
@@ -92,8 +92,10 @@ namespace Neo4jClient.Test.Cypher
             public string CamelCaseProperty { get; set; }
         }
 
-        [Fact]
-        public void ComplexObjectInWithParam()
+        [Theory]
+        [InlineData("{obj}")]
+        [InlineData("$obj")]
+        public void ComplexObjectInWithParam(string param)
         {
             // Arrange
             var client = Substitute.For<IRawGraphClient>();
@@ -101,7 +103,7 @@ namespace Neo4jClient.Test.Cypher
             // Act
             var query = new CypherFluentQuery(client)
                 .Start("n", (NodeReference) 3)
-                .CreateUnique("n-[:X]-(leaf {obj})")
+                .CreateUnique($"n-[:X]-(leaf {param})")
                 .WithParam("obj", CreateComplexObjForWithParamTest())
                 .Query;
 
@@ -127,8 +129,10 @@ namespace Neo4jClient.Test.Cypher
             };
         }
 
-        [Fact]
-        public void ComplexObjectInWithParamCamelCase()
+        [Theory]
+        [InlineData("{obj}")]
+        [InlineData("$obj")]
+        public void ComplexObjectInWithParamCamelCase(string param)
         {
             // Arrange
             var client = Substitute.For<IRawGraphClient>();
@@ -137,7 +141,7 @@ namespace Neo4jClient.Test.Cypher
             // Act
             var query = new CypherFluentQuery(client)
                 .Start("n", (NodeReference)3)
-                .CreateUnique("n-[:X]-(leaf {obj})")
+                .CreateUnique($"n-[:X]-(leaf {param})")
                 .WithParam("obj", CreateComplexObjForWithParamTest())
                 .Query;
 

--- a/Neo4jClient.Tests.Shared/Cypher/CypherQueryTests.cs
+++ b/Neo4jClient.Tests.Shared/Cypher/CypherQueryTests.cs
@@ -102,5 +102,26 @@ namespace Neo4jClient.Test.Cypher
             const string expected = "MATCH null";
             Assert.Equal(expected, query.DebugQueryText);
         }
+
+        [Fact]        
+        public void DebugQueryTextShouldSubstituteBothParameterSyntaxStyles()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            var query = new CypherFluentQuery(client)
+                .Match("$paramDollar")
+                .WithParams(new
+                {
+                    paramDollar = 123
+                })
+                .Match("{paramBraces}")
+                .WithParams(new
+                {
+                    paramBraces = 456
+                })
+                .Query;
+
+            const string expected = "MATCH 123\r\nMATCH 456";
+            Assert.Equal(expected, query.DebugQueryText);
+        }
     }
 }

--- a/Neo4jClient.Tests.Shared/Cypher/CypherQueryTests.cs
+++ b/Neo4jClient.Tests.Shared/Cypher/CypherQueryTests.cs
@@ -30,12 +30,14 @@ namespace Neo4jClient.Test.Cypher
             Assert.Equal(expected, query.DebugQueryText);
         }
 
-        [Fact]
-        public void DebugQueryTextShouldSubstituteNumericParameters()
+        [Theory]
+        [InlineData("{param}")]
+        [InlineData("$param")]
+        public void DebugQueryTextShouldSubstituteNumericParameters(string match)
         {
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
-                .Match("{param}")
+                .Match(match)
                 .WithParams(new
                 {
                     param = 123
@@ -46,12 +48,14 @@ namespace Neo4jClient.Test.Cypher
             Assert.Equal(expected, query.DebugQueryText);
         }
 
-        [Fact]
-        public void DebugQueryTextShouldSubstituteStringParametersWithEncoding()
+        [Theory]
+        [InlineData("{param}")]
+        [InlineData("$param")]
+        public void DebugQueryTextShouldSubstituteStringParametersWithEncoding(string match)
         {
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
-                .Match("{param}")
+                .Match(match)
                 .WithParams(new
                 {
                     param = "hello"
@@ -62,12 +66,14 @@ namespace Neo4jClient.Test.Cypher
             Assert.Equal(expected, query.DebugQueryText);
         }
 
-        [Fact]
-        public void DebugQueryTextShouldSubstituteStringParametersWithEncodingOfSpecialCharacters()
+        [Theory]
+        [InlineData("{param}")]
+        [InlineData("$param")]
+        public void DebugQueryTextShouldSubstituteStringParametersWithEncodingOfSpecialCharacters(string match)
         {
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
-                .Match("{param}")
+                .Match(match)
                 .WithParams(new
                 {
                     param = "hel\"lo"
@@ -78,13 +84,15 @@ namespace Neo4jClient.Test.Cypher
             Assert.Equal(expected, query.DebugQueryText);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("{param}")]
+        [InlineData("$param")]
         //[Description("https://github.com/Readify/Neo4jClient/issues/50")]
-        public void DebugQueryTextShouldSubstituteNullParameters()
+        public void DebugQueryTextShouldSubstituteNullParameters(string match)
         {
             var client = Substitute.For<IRawGraphClient>();
             var query = new CypherFluentQuery(client)
-                .Match("{param}")
+                .Match(match)
                 .WithParams(new
                 {
                     param = (string)null


### PR DESCRIPTION
The parameter syntax currently used in the DebugQueryText will be deprecated.

https://neo4j.com/docs/developer-manual/3.4-preview/cypher/syntax/parameters/

Added ability to correctly replace either $param or {param} syntax  so DebugQueryText is correctly displayed