### PR TITLE
Don't throw when Location-header is missing

### DIFF
--- a/Neo4jClient.Shared/Execution/CypherExecutionPolicy.cs
+++ b/Neo4jClient.Shared/Execution/CypherExecutionPolicy.cs
@@ -57,7 +57,13 @@ namespace Neo4jClient.Execution
                 return;
             }
 
-            var locationHeader = executionMetadata["Location"] as IEnumerable<string>;
+            object locationValue;
+            if (!executionMetadata.TryGetValue("Location", out locationValue))
+            {
+                return;
+            }
+
+            var locationHeader = locationValue as IEnumerable<string>;
             if (locationHeader == null)
             {
                 return;


### PR DESCRIPTION
This header doesn't always exist, which would throw an
`KeyNotFoundException`.

Fixes #298