### PR TITLE
Fix testcase for daylight saving

### DIFF
--- a/Neo4jClient.Tests.Shared/Extensions/Neo4jDriverExtensionsTests.cs
+++ b/Neo4jClient.Tests.Shared/Extensions/Neo4jDriverExtensionsTests.cs
@@ -274,7 +274,7 @@ namespace Neo4jClient.Test.Extensions
                 actual["p"].Should().BeOfType<Dictionary<string, object>>();
                 var serializedObj = (Dictionary<string, object>) actual["p"];
 
-                serializedObj["Dt"].Should().Be(630822816000000000);
+                serializedObj["Dt"].Should().Be(dateTime.ToUniversalTime().Ticks);
             }
         }
     }


### PR DESCRIPTION
The `dateTime` in the test used local time, but the date was stored in UTC.
The test assumed that local time and UTC is the same, which isn't true in all cases.