### PR TITLE
Fix concurrency issues

### DIFF
--- a/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
@@ -34,15 +34,15 @@ namespace Neo4jClient.Transactions
             // [See Issue #284]
             get
             {
-                if (scopedTransactions != null && scopedTransactions.Value != null)
+                if (scopedTransactions == null)
                 {
-                    return scopedTransactions.Value;
+                    scopedTransactions = new AsyncLocal<IScopedTransactions<BoltTransactionScopeProxy>>();
                 }
 
-                scopedTransactions = new AsyncLocal<IScopedTransactions<BoltTransactionScopeProxy>>
+                if (scopedTransactions.Value == null)
                 {
-                    Value = ThreadContextHelper.CreateBoltScopedTransactions()
-                };
+                    scopedTransactions.Value = ThreadContextHelper.CreateBoltScopedTransactions();
+                }
 
                 return scopedTransactions.Value;
             }

--- a/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
@@ -50,15 +50,10 @@ namespace Neo4jClient.Transactions
             {
                 if (scopedTransactions == null)
                 {
-                    scopedTransactions = new AsyncLocal<IScopedTransactions<BoltTransactionScopeProxy>>
-                    {
-                        Value = value
-                    };
+                    scopedTransactions = new AsyncLocal<IScopedTransactions<BoltTransactionScopeProxy>>();
                 }
-                else
-                {
-                    scopedTransactions.Value = value;
-                }
+
+                scopedTransactions.Value = value;
             }
         }
 #endif

--- a/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
@@ -52,7 +52,7 @@ namespace Neo4jClient.Transactions
                 {
                     scopedTransactions = new AsyncLocal<IScopedTransactions<BoltTransactionScopeProxy>>
                     {
-                        Value = ThreadContextHelper.CreateBoltScopedTransactions()
+                        Value = value
                     };
                 }
                 else

--- a/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionPromotableSinglePhasesNotification.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionPromotableSinglePhasesNotification.cs
@@ -59,13 +59,12 @@ namespace Neo4jClient.Transactions
                 transaction.Commit();
                 transaction.Dispose();
                 transaction = null;
-                singlePhaseEnlistment.Committed();
             }
             else if(transactionId != Guid.Empty)
             {
                 ResourceManager.CommitTransaction(transactionId);
-                singlePhaseEnlistment.Committed();
             }
+            singlePhaseEnlistment.Committed();
 
             enlistedInTransactions.Remove(Transaction.Current);
         }

--- a/Neo4jClient.Full.Shared/Transactions/BoltNeo4jTransaction.cs
+++ b/Neo4jClient.Full.Shared/Transactions/BoltNeo4jTransaction.cs
@@ -89,11 +89,13 @@ namespace Neo4jClient.Transactions
         public static void DoCommit(ITransactionExecutionEnvironmentBolt transactionExecutionEnvironment)
         {
             transactionExecutionEnvironment.DriverTransaction.Success();
+            transactionExecutionEnvironment.DriverTransaction.Dispose();
         }
 
         public static void DoRollback(ITransactionExecutionEnvironmentBolt transactionExecutionEnvironment)
         {
             transactionExecutionEnvironment.DriverTransaction.Failure();
+            transactionExecutionEnvironment.DriverTransaction.Dispose();
         }
 
         public static BoltNeo4jTransaction FromIdAndClient(Guid transactionId, IDriver driver)

--- a/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
@@ -64,9 +64,14 @@ namespace Neo4jClient.Transactions
                 BoltNeo4jTransaction.DoCommit(transactionExecutionEnvironment);
                 singlePhaseEnlistment.Committed();
             }
+            catch (Exception e)
+            {
+                singlePhaseEnlistment.Aborted(e);
+                // TODO: Should we rethrow?
+            }
             finally
             {
-                singlePhaseEnlistment.Aborted();
+                singlePhaseEnlistment.Done();
             }
         }
 
@@ -141,9 +146,14 @@ namespace Neo4jClient.Transactions
                 Neo4jRestTransaction.DoCommit(transactionExecutionEnvironment);
                 singlePhaseEnlistment.Committed();
             }
+            catch (Exception e)
+            {
+                singlePhaseEnlistment.Aborted(e);
+                // TODO: Should we rethrow?
+            }
             finally
             {
-                singlePhaseEnlistment.Aborted();
+                singlePhaseEnlistment.Done();
             }
         }
 

--- a/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
@@ -36,7 +36,7 @@ namespace Neo4jClient.Transactions
         {
             try
             {
-              BoltNeo4jTransaction.DoRollback(transactionExecutionEnvironment);
+                BoltNeo4jTransaction.DoRollback(transactionExecutionEnvironment);
             }
             finally
             {

--- a/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
@@ -172,8 +172,9 @@ namespace Neo4jClient.Transactions
             CommittableTransaction tx;
             if (transactions.TryGetValue(transactionId, out tx))
             {
-                transactions.Remove(transactionId);
                 tx.Rollback();
+                tx.Dispose();
+                transactions.Remove(transactionId);
             }
         }
 
@@ -233,6 +234,7 @@ namespace Neo4jClient.Transactions
             if (transactions.TryGetValue(transactionId, out tx))
             {
                 tx.Commit();
+                tx.Dispose();
                 transactions.Remove(transactionId);
             }
         }
@@ -242,8 +244,9 @@ namespace Neo4jClient.Transactions
             CommittableTransaction tx;
             if (transactions.TryGetValue(transactionId, out tx))
             {
-                transactions.Remove(transactionId);
                 tx.Rollback();
+                tx.Dispose();
+                transactions.Remove(transactionId);
             }
         }
 

--- a/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Neo4jTransactionResourceManager.cs
@@ -15,8 +15,15 @@ namespace Neo4jClient.Transactions
 
         public void Prepare(PreparingEnlistment preparingEnlistment)
         {
-//            BoltNeo4jTransaction.DoKeepAlive(transactionExecutionEnvironment);
-            preparingEnlistment.Done();
+            try
+            {
+                // Nothing to do
+                preparingEnlistment.Prepared();
+            }
+            catch (Exception e)
+            {
+                preparingEnlistment.ForceRollback(e);
+            }
         }
 
         public void Commit(Enlistment enlistment)
@@ -85,8 +92,15 @@ namespace Neo4jClient.Transactions
 
         public void Prepare(PreparingEnlistment preparingEnlistment)
         {
-            Neo4jRestTransaction.DoKeepAlive(transactionExecutionEnvironment);
-            preparingEnlistment.Done();
+            try
+            {
+                Neo4jRestTransaction.DoKeepAlive(transactionExecutionEnvironment);
+                preparingEnlistment.Prepared();
+            }
+            catch (Exception e)
+            {
+                preparingEnlistment.ForceRollback(e);
+            }
         }
 
         public void Commit(Enlistment enlistment)

--- a/Neo4jClient.Full.Shared/Transactions/TransactionSinglePhaseNotification.cs
+++ b/Neo4jClient.Full.Shared/Transactions/TransactionSinglePhaseNotification.cs
@@ -120,13 +120,12 @@ namespace Neo4jClient.Transactions
             {
                 transaction.Commit();
                 transaction = null;
-                singlePhaseEnlistment.Committed();
             }
             else if (transactionId > 0)
             {
                 GetResourceManager().CommitTransaction(transactionId);
-                singlePhaseEnlistment.Committed();
             }
+            singlePhaseEnlistment.Committed();
 
             enlistedInTransactions.Remove(Transaction.Current);
         }

--- a/Neo4jClient.Full.Shared/Transactions/TransactionSinglePhaseNotification.cs
+++ b/Neo4jClient.Full.Shared/Transactions/TransactionSinglePhaseNotification.cs
@@ -119,6 +119,7 @@ namespace Neo4jClient.Transactions
             if (transaction != null)
             {
                 transaction.Commit();
+                transaction.Dispose();
                 transaction = null;
             }
             else if (transactionId > 0)
@@ -137,6 +138,7 @@ namespace Neo4jClient.Transactions
             if (transaction != null)
             {
                 transaction.Rollback();
+                transaction.Dispose();
                 transaction = null;
             }
             else if (transactionId > 0)

--- a/Neo4jClient.Tests.Shared/CultureInfoSetupFixture.cs
+++ b/Neo4jClient.Tests.Shared/CultureInfoSetupFixture.cs
@@ -6,14 +6,20 @@ namespace Neo4jClient.Test.Fixtures
     public class CultureInfoSetupFixture
     {
         //SetCultureToSomethingNonLatinToEnsureCodeUnderTestDoesntAssumeEnAu()
+        public static readonly CultureInfo CultureInfo = new CultureInfo("zh-CN");
+
+        public static void SetDeterministicCulture()
+        {
+            Thread.CurrentThread.CurrentCulture = Thread.CurrentThread.CurrentUICulture = CultureInfo;
+        }
+
         public CultureInfoSetupFixture()
         {
             // Issue https://bitbucket.org/Readify/neo4jclient/issue/15/take-cultureinfo-into-account-for-proper
 
             // The idea is to minimize developer mistake by surprising culture-info assumptions. This may not be the best setup for culture-dependent
             // tests. The alternative of introducing test base class is deliberately not taken because deriving from it is another assumption by itself.
-            var thread = Thread.CurrentThread;
-            thread.CurrentCulture = thread.CurrentUICulture = new CultureInfo("zh-CN");
+            SetDeterministicCulture();
         }
     }
 }

--- a/Neo4jClient.Tests.Shared/Extensions/Neo4jDriverExtensionsTests.cs
+++ b/Neo4jClient.Tests.Shared/Extensions/Neo4jDriverExtensionsTests.cs
@@ -274,7 +274,7 @@ namespace Neo4jClient.Test.Extensions
                 actual["p"].Should().BeOfType<Dictionary<string, object>>();
                 var serializedObj = (Dictionary<string, object>) actual["p"];
 
-                serializedObj["Dt"].Should().Be(630822816000000000);
+                serializedObj["Dt"].Should().Be(dateTime.ToUniversalTime().Ticks);
             }
         }
     }

--- a/Neo4jClient.Tests.Shared/Serialization/CypherJsonDeserializerTests.cs
+++ b/Neo4jClient.Tests.Shared/Serialization/CypherJsonDeserializerTests.cs
@@ -72,7 +72,12 @@ namespace Neo4jClient.Test.Serialization
                     yield return new object[]{CypherResultMode.Projection, CypherResultFormat.Rest, ProjectionModeContentFormat, "2012-08-31T10:11:00.3642578+10:00", "2012-08-31 10:11:00 +10:00"};
                 }
             }
-        }          
+        }
+
+        public CypherJsonDeserializerTests()
+        {
+            CultureInfoSetupFixture.SetDeterministicCulture();
+        }
                     
         [Theory]
         [MemberData(nameof(DateTimeOffsetCasesFactory.TestCases), MemberType = typeof(DateTimeOffsetCasesFactory))]

--- a/Neo4jClient.Tests.Shared/Serialization/UserSuppliedSerializationTests.cs
+++ b/Neo4jClient.Tests.Shared/Serialization/UserSuppliedSerializationTests.cs
@@ -10,6 +10,11 @@ namespace Neo4jClient.Test.Serialization
     
     public class UserSuppliedSerializationTests : IClassFixture<CultureInfoSetupFixture>
     {
+        public UserSuppliedSerializationTests()
+        {
+            CultureInfoSetupFixture.SetDeterministicCulture();
+        }
+
         public class TestValueA
         {
             public char A { get; set; }


### PR DESCRIPTION
This fixes several issues:
- Flaky tests
- Cross thread transactions (AsyncLocal for storing transactions)
- SinglePhaseCommit never commiting (only Prepare called, never Commit)
- Commit not commiting (Dispose not called for Neo4j.Driver)
- Commit not commiting (Neo4j.Driver not implementing MarshalByRefObject)
- Transactions getting lost on .NET 4.7.1

I'm not sure about all these changes. In particular the last one is a workaround which we're waiting for an answer from Microsoft if our workaround is sound or subtly broken, ref https://github.com/Microsoft/dotnet-framework-early-access/issues/7#issuecomment-435377965

In order for commit to work on promoted Bolt transactions, we also need a patch in Neo4j.Driver: https://github.com/neo4j/neo4j-dotnet-driver/pull/328
