### PR TITLE
Only have a single AsyncLocal for the transaction manager

### DIFF
--- a/Neo4jClient.Full.Shared/Transactions/ThreadContextHelpers.cs
+++ b/Neo4jClient.Full.Shared/Transactions/ThreadContextHelpers.cs
@@ -21,7 +21,9 @@ namespace Neo4jClient.Transactions
         bool HasValue { get; }
         void Push(T item);
         T Pop();
+        T TryPop();
         T Peek();
+        T TryPeek();
     }
 
     internal class ThreadContextWrapper<T>
@@ -44,9 +46,19 @@ namespace Neo4jClient.Transactions
             return _stack.Peek();
         }
 
+        public T TryPeek()
+        {
+            return _stack.Count > 0 ? _stack.Peek() : null;
+        }
+
         public T Pop()
         {
             return _stack.Pop();
+        }
+
+        public T TryPop()
+        {
+            return _stack.Count > 0 ? _stack.Pop() : null;
         }
 
         public void Push(T item)


### PR DESCRIPTION
We use a single AsyncLocal rather than replacing the global value for each
transaction manager. This makes it possible to run multiple transaction
managers in parallel without clearing each others values.

- Fixes ScopedTransaction is `null`
  - ref https://github.com/Readify/Neo4jClient/issues/300

It also seems to have fixed, or at least drastically reduced, the following:
- Neo4j.Driver "The Read method cannot be called when another read operation is pending"
  - ref https://github.com/neo4j/neo4j-dotnet-driver/issues/329
- Neo4j.Driver "A blocking operation was interrupted by a call to WSACancelBlockingCall"
  - ref https://github.com/neo4j/neo4j-dotnet-driver/issues/329

I'm unsure about the correct behavior in Dispose -- should we really just set the
ScopedTransactions to null? Or should we do some other cleanup?