### PR TITLE
Upgrade Neo4j.Driver and switch from Neo4j.Driver to Neo4j.Driver.Signed

### DIFF
--- a/Neo4jClient.Full/Neo4jClient.Full.csproj
+++ b/Neo4jClient.Full/Neo4jClient.Full.csproj
@@ -65,8 +65,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo4j.Driver.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
+    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, PublicKeyToken=c08b0bc1c355082b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo4j.Driver.Signed.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Neo4jClient.Full/Neo4jClient.Full.csproj
+++ b/Neo4jClient.Full/Neo4jClient.Full.csproj
@@ -65,8 +65,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Neo4j.Driver, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo4j.Driver.1.5.2\lib\net452\Neo4j.Driver.dll</HintPath>
+    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo4j.Driver.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Neo4jClient.Full/packages.config
+++ b/Neo4jClient.Full/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.NETCore.Platforms" version="2.0.0" targetFramework="net46" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
-  <package id="Neo4j.Driver" version="1.5.2" targetFramework="net46" />
+  <package id="Neo4j.Driver" version="1.7.0" targetFramework="net46" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />

--- a/Neo4jClient.Full/packages.config
+++ b/Neo4jClient.Full/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.NETCore.Platforms" version="2.0.0" targetFramework="net46" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
-  <package id="Neo4j.Driver" version="1.7.0" targetFramework="net46" />
+  <package id="Neo4j.Driver.Signed" version="1.7.0" targetFramework="net46" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />

--- a/Neo4jClient.Full452/Neo4jClient.Full452.csproj
+++ b/Neo4jClient.Full452/Neo4jClient.Full452.csproj
@@ -33,8 +33,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Neo4j.Driver, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo4j.Driver.1.5.2\lib\net452\Neo4j.Driver.dll</HintPath>
+    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo4j.Driver.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Neo4jClient.Full452/Neo4jClient.Full452.csproj
+++ b/Neo4jClient.Full452/Neo4jClient.Full452.csproj
@@ -33,8 +33,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo4j.Driver.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
+    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, PublicKeyToken=c08b0bc1c355082b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo4j.Driver.Signed.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Neo4jClient.Full452/packages.config
+++ b/Neo4jClient.Full452/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.NETCore.Platforms" version="2.0.0" targetFramework="net452" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net452" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net452" />
-  <package id="Neo4j.Driver" version="1.7.0" targetFramework="net452" />
+  <package id="Neo4j.Driver.Signed" version="1.7.0" targetFramework="net452" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net452" />

--- a/Neo4jClient.Full452/packages.config
+++ b/Neo4jClient.Full452/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.NETCore.Platforms" version="2.0.0" targetFramework="net452" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net452" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net452" />
-  <package id="Neo4j.Driver" version="1.5.2" targetFramework="net452" />
+  <package id="Neo4j.Driver" version="1.7.0" targetFramework="net452" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net452" />

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -72,8 +72,8 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo4j.Driver.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
+    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, PublicKeyToken=c08b0bc1c355082b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo4j.Driver.Signed.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Neo4jClient.Tests/Neo4jClient.Tests.csproj
+++ b/Neo4jClient.Tests/Neo4jClient.Tests.csproj
@@ -72,8 +72,8 @@
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.2\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Neo4j.Driver, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo4j.Driver.1.5.2\lib\net452\Neo4j.Driver.dll</HintPath>
+    <Reference Include="Neo4j.Driver, Version=1.7.91.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo4j.Driver.1.7.0\lib\net452\Neo4j.Driver.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Neo4jClient.Tests/packages.config
+++ b/Neo4jClient.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="Moq" version="4.8.2" targetFramework="net461" />
-  <package id="Neo4j.Driver" version="1.5.2" targetFramework="net461" />
+  <package id="Neo4j.Driver" version="1.7.0" targetFramework="net461" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />

--- a/Neo4jClient.Tests/packages.config
+++ b/Neo4jClient.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="Moq" version="4.8.2" targetFramework="net461" />
-  <package id="Neo4j.Driver" version="1.7.0" targetFramework="net461" />
+  <package id="Neo4j.Driver.Signed" version="1.7.0" targetFramework="net461" />
   <package id="NETStandard.Library" version="2.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />

--- a/Neo4jClient/project.json
+++ b/Neo4jClient/project.json
@@ -4,7 +4,7 @@
     "Microsoft.DependencyValidation.Analyzers": "0.9.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "Microsoft.VisualBasic": "10.2.0",
-    "Neo4j.Driver": "1.7.0",
+    "Neo4j.Driver.Signed": "1.7.0",
     "NETStandard.Library": "2.0.0",
     "Newtonsoft.Json": "9.0.1",
     "System.Collections": "4.3.0",

--- a/Neo4jClient/project.json
+++ b/Neo4jClient/project.json
@@ -4,7 +4,7 @@
     "Microsoft.DependencyValidation.Analyzers": "0.9.0",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "Microsoft.VisualBasic": "10.2.0",
-    "Neo4j.Driver": "1.5.2",
+    "Neo4j.Driver": "1.7.0",
     "NETStandard.Library": "2.0.0",
     "Newtonsoft.Json": "9.0.1",
     "System.Collections": "4.3.0",


### PR DESCRIPTION
Only signed assemblies can be redirected. Signed assemblies has to be signed all the way down. Until #279 is resolved, this change allows us to self-sign neo4jclient so it can be referenced in multiple libraries without causing problems.