### PR TITLE
Use System.Net.Http from NET Framework rather than NuGet

### DIFF
--- a/Neo4jClient.Full/Neo4jClient.Full.csproj
+++ b/Neo4jClient.Full/Neo4jClient.Full.csproj
@@ -73,9 +73,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Net.Http, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.3.2\lib\net46\System.Net.Http.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Transactions" />
     <Reference Include="Microsoft.CSharp" />
@@ -96,13 +94,6 @@
   <Import Project="..\Neo4jClient.Shared\Neo4jClient.Shared.projitems" Label="Shared" />
   <Import Project="..\Neo4jClient.Full.Shared\Neo4jClient.Full.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\NETStandard.Library.2.0.0\build\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.0\build\NETStandard.Library.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NETStandard.Library.2.0.0\build\NETStandard.Library.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NETStandard.Library.2.0.0\build\NETStandard.Library.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Neo4jClient.Full/packages.config
+++ b/Neo4jClient.Full/packages.config
@@ -5,7 +5,6 @@
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net46" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="Neo4j.Driver" version="1.5.2" targetFramework="net46" />
-  <package id="NETStandard.Library" version="2.0.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net46" />
@@ -24,7 +23,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
-  <package id="System.Net.Http" version="4.3.2" targetFramework="net46" />
   <package id="System.Net.NameResolution" version="4.3.0" targetFramework="net46" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Net.Security" version="4.3.1" targetFramework="net46" />

--- a/Neo4jClient.Full452/packages.config
+++ b/Neo4jClient.Full452/packages.config
@@ -5,7 +5,6 @@
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" targetFramework="net452" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="Neo4j.Driver" version="1.5.2" targetFramework="net452" />
-  <package id="NETStandard.Library" version="2.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
@@ -24,7 +23,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
-  <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
   <package id="System.Net.NameResolution" version="4.3.0" targetFramework="net452" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.Net.Security" version="4.3.1" targetFramework="net452" />

--- a/Neo4jClient.nuspec
+++ b/Neo4jClient.nuspec
@@ -12,7 +12,6 @@
     <dependencies>
       <group targetFramework="net452">
         <dependency id="Newtonsoft.Json" version="9.0.1" />
-        <dependency id="System.Net.Http" version="4.3.2" />
         <dependency id="Neo4j.Driver" version="1.5.2" />        
       </group>
       <group targetFramework="netstandard1.3">
@@ -27,7 +26,6 @@
       </group>
       <group targetFramework="net46">
         <dependency id="Newtonsoft.Json" version="9.0.1" />
-        <dependency id="System.Net.Http" version="4.3.2" />
         <dependency id="Neo4j.Driver" version="1.5.2" />
       </group>
     </dependencies>


### PR DESCRIPTION
The System.Net.Http package on NuGet was put there as an OOB update where
Microsoft also tried to add extra functionality for NET Framework developers.

This experiment didn't work, but Microsoft didn't want to pull the package from
NuGet as people would get strange errors.

Microsoft has written a post-mortem on GitHub, ref
https://github.com/dotnet/corefx/issues/17522#issuecomment-338418610

NOTE: I also had to remove NETStandard.Library from NET Framework as that
      depends on System.Net.Http from NuGet.