### PR TITLE
Adds support for Bookmarks

### DIFF
--- a/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionManager.cs
@@ -125,8 +125,9 @@ namespace Neo4jClient.Transactions
         /// <param name="scopeOption">How should the transaction scope be created.
         /// <see cref="Neo4jClient.Transactions.ITransactionalGraphClient.BeginTransaction(Neo4jClient.Transactions.TransactionScopeOption)" />
         ///  for more information.</param>
+        /// <param name="bookmarks">Bookmarks for use with this transaction.</param>
         /// <returns></returns>
-        public ITransaction BeginTransaction(TransactionScopeOption scopeOption)
+        public ITransaction BeginTransaction(TransactionScopeOption scopeOption, IEnumerable<string> bookmarks)
         {
             if (scopeOption == TransactionScopeOption.Suppress)
             {
@@ -151,12 +152,12 @@ namespace Neo4jClient.Transactions
             }
 
             // then scopeOption == TransactionScopeOption.RequiresNew or we dont have a current transaction
-            return BeginNewTransaction();
+            return BeginNewTransaction(bookmarks);
         }
 
-        private BoltTransactionContext GenerateTransaction()
+        private BoltTransactionContext GenerateTransaction(IEnumerable<string> bookmarks)
         {
-            var session = ((BoltGraphClient)client).Driver.Session();
+            var session = ((BoltGraphClient)client).Driver.Session(bookmarks);
             var transaction = session.BeginTransaction();
             return new BoltTransactionContext(new BoltNeo4jTransaction(session, transaction));
         }
@@ -171,9 +172,9 @@ namespace Neo4jClient.Transactions
             ScopedTransactions.Push(transaction);
         }
 
-        private ITransaction BeginNewTransaction()
+        private ITransaction BeginNewTransaction(IEnumerable<string> bookmarks)
         {
-            var transaction = new BoltNeo4jTransactionProxy(client, GenerateTransaction(), true);
+            var transaction = new BoltNeo4jTransactionProxy(client, GenerateTransaction(bookmarks), true);
             PushScopeTransaction(transaction);
             return transaction;
         }

--- a/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionPromotableSinglePhasesNotification.cs
+++ b/Neo4jClient.Full.Shared/Transactions/Bolt/BoltTransactionPromotableSinglePhasesNotification.cs
@@ -22,13 +22,14 @@ namespace Neo4jClient.Transactions
             // we have been promoted to MSTDC, so we have to clean the local resources
             if (transaction == null)
             {
-                transaction = new BoltNeo4jTransaction(((BoltGraphClient)client).Driver );
+                transaction = new BoltNeo4jTransaction(((BoltGraphClient)client).Driver, null );
             }
             
             transaction.Cancel();
             transactionId = transaction.Id;
             var driverTx = transaction.DriverTransaction;
             var session = transaction.Session;
+            var bookmarks = transaction.Bookmarks;
             transaction = null;
 
             // BUG: .NET 4.7.1 introduced a bug where the current transaction wouldn't get restored
@@ -39,7 +40,8 @@ namespace Neo4jClient.Transactions
             {
                 TransactionId = transactionId,
                 Session = session,
-                DriverTransaction = driverTx
+                DriverTransaction = driverTx,
+                Bookmarks = bookmarks
             });
             // Only restore if the bug exists to avoid any potentially side-effects
             // of setting the transaction
@@ -57,7 +59,7 @@ namespace Neo4jClient.Transactions
         /// <inheritdoc />
         public void Initialize()
         {
-            transaction = new BoltNeo4jTransaction(((BoltGraphClient)client).Driver);
+            transaction = new BoltNeo4jTransaction(((BoltGraphClient)client).Driver, null);
         }
 
         /// <inheritdoc />
@@ -123,7 +125,7 @@ namespace Neo4jClient.Transactions
 
                 // we create a transaction directly instead of using BeginTransaction that GraphClient
                 // doesn't store it in its stack of scopes.
-                var localTransaction = new BoltNeo4jTransaction(((BoltGraphClient)client).Driver);
+                var localTransaction = new BoltNeo4jTransaction(((BoltGraphClient)client).Driver, null);
 
                
                 var propagationToken = TransactionInterop.GetTransmitterPropagationToken(transaction);

--- a/Neo4jClient.Full.Shared/Transactions/TransactionExecutionEnvironment.cs
+++ b/Neo4jClient.Full.Shared/Transactions/TransactionExecutionEnvironment.cs
@@ -15,6 +15,7 @@ namespace Neo4jClient.Transactions
         public Guid ResourceManagerId { get; set; }
         public ISession Session { get; set; }
         public Neo4j.Driver.V1.ITransaction DriverTransaction { get; set; }
+        public IList<string> Bookmarks { get; set; }
 
         public BoltTransactionExecutionEnvironment(ExecutionConfiguration executionConfiguration)
         {

--- a/Neo4jClient.Full.Shared/Transactions/TransactionManager.cs
+++ b/Neo4jClient.Full.Shared/Transactions/TransactionManager.cs
@@ -118,6 +118,11 @@ namespace Neo4jClient.Transactions
 
         public ITransaction CurrentDtcTransaction => Transaction.Current == null ? null : promotable.AmbientTransaction;
 
+        public ITransaction BeginTransaction(TransactionScopeOption scopeOption, IEnumerable<string> bookmarks)
+        {
+            return BeginTransaction(scopeOption);
+        }
+
         /// <summary>
         /// Implements the internal part for ITransactionalGraphClient.BeginTransaction
         /// </summary>
@@ -202,6 +207,8 @@ namespace Neo4jClient.Transactions
             PushScopeTransaction(suppressTransaction);
             return suppressTransaction;
         }
+
+ 
 
         public void EndTransaction()
         {

--- a/Neo4jClient.Shared/Cypher/CypherFluentQuery.cs
+++ b/Neo4jClient.Shared/Cypher/CypherFluentQuery.cs
@@ -48,10 +48,7 @@ namespace Neo4jClient.Cypher
 
         internal CypherFluentQuery(IGraphClient client, QueryWriter queryWriter, bool isWrite = true)
         {
-            if (!(client is IRawGraphClient))
-                throw new ArgumentException("The supplied graph client also needs to implement IRawGraphClient", nameof(client));
-
-            Client = (IRawGraphClient)client;
+            Client = client as IRawGraphClient ?? throw new ArgumentException("The supplied graph client also needs to implement IRawGraphClient", nameof(client));
             QueryWriter = queryWriter;
             CamelCaseProperties = Client.JsonContractResolver is CamelCasePropertyNamesContractResolver;
             Advanced = new CypherFluentQueryAdvanced(Client, QueryWriter, isWrite);
@@ -505,8 +502,7 @@ namespace Neo4jClient.Cypher
                     throw new ArgumentOutOfRangeException(nameof(planner), planner, null);
             }
         }
-
-
+        
         public ICypherFluentQuery MaxExecutionTime(int milliseconds)
         {
             QueryWriter.MaxExecutionTime = milliseconds;
@@ -524,6 +520,13 @@ namespace Neo4jClient.Cypher
             return isCamelCase 
                 ? $"{propertyName.Substring(0, 1).ToLowerInvariant()}{(propertyName.Length > 1 ? propertyName.Substring(1, propertyName.Length - 1) : string.Empty)}"
                 : propertyName;
+        }
+
+        /// <inheritdoc />
+        public ICypherFluentQuery WithIdentifier(string identifier)
+        {
+            QueryWriter.Identifier = string.IsNullOrWhiteSpace(identifier) ? null : identifier;
+            return this;
         }
     }
 }

--- a/Neo4jClient.Shared/Cypher/CypherFluentQuery`WithBookmark.cs
+++ b/Neo4jClient.Shared/Cypher/CypherFluentQuery`WithBookmark.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+
+namespace Neo4jClient.Cypher
+{
+    public partial class CypherFluentQuery
+    {
+        /// <inheritdoc />
+        public ICypherFluentQuery WithBookmark(string bookmark)
+        {
+            if (string.IsNullOrWhiteSpace(bookmark))
+                return this;
+
+            QueryWriter.Bookmarks.Add(bookmark);
+            return this;
+        }
+
+        /// <inheritdoc />
+        public ICypherFluentQuery WithBookmarks(params string[] bookmarks)
+        {
+            QueryWriter.Bookmarks.AddRange(bookmarks.Where(b => !string.IsNullOrWhiteSpace(b)));
+            return this;
+        }
+    }
+}

--- a/Neo4jClient.Shared/Cypher/CypherQuery.cs
+++ b/Neo4jClient.Shared/Cypher/CypherQuery.cs
@@ -17,6 +17,7 @@ namespace Neo4jClient.Cypher
     [DebuggerDisplay("{DebugQueryText}")]
     public class CypherQuery
     {
+        
         readonly string queryText;
         readonly IDictionary<string, object> queryParameters;
         readonly CypherResultMode resultMode;
@@ -24,8 +25,7 @@ namespace Neo4jClient.Cypher
         readonly IContractResolver jsonContractResolver;
         readonly int? maxExecutionTime;
         private readonly NameValueCollection customHeaders;
-        public bool IsWrite { get; }
-
+        
         public CypherQuery(
             string queryText,
             IDictionary<string, object> queryParameters,
@@ -43,7 +43,9 @@ namespace Neo4jClient.Cypher
             IContractResolver contractResolver = null, 
             int? maxExecutionTime = null, 
             NameValueCollection customHeaders = null,
-            bool isWrite = true
+            bool isWrite = true,
+            IEnumerable<string> bookmarks = null,
+            string identifier = null
             )
         {
             this.queryText = queryText;
@@ -54,7 +56,15 @@ namespace Neo4jClient.Cypher
             this.maxExecutionTime = maxExecutionTime;
             this.customHeaders = customHeaders;
             IsWrite = isWrite;
+            Bookmarks = bookmarks;
+            Identifier = identifier;
         }
+
+        public bool IsWrite { get; }
+
+        public string Identifier { get; set; }
+
+        public IEnumerable<string> Bookmarks { get; set; }
 
         public IDictionary<string, object> QueryParameters => queryParameters;
 

--- a/Neo4jClient.Shared/Cypher/ICypherFluentQuery.cs
+++ b/Neo4jClient.Shared/Cypher/ICypherFluentQuery.cs
@@ -153,11 +153,37 @@ namespace Neo4jClient.Cypher
         /// Set the query to be a Read query.
         /// </summary>
         /// <remarks>This is used by the <see cref="BoltGraphClient"/></remarks>
+        /// /// <returns>A <see cref="ICypherFluentQuery"/> instance to continue querying with.</returns>
         ICypherFluentQuery Read { get; }
+
         /// <summary>
         /// Set the query to be a Write query (which is the default behaviour).
         /// </summary>
         /// <remarks>This is used by the <see cref="BoltGraphClient"/></remarks>
+        /// <returns>A <see cref="ICypherFluentQuery"/> instance to continue querying with.</returns>
         ICypherFluentQuery Write { get; }
+
+        /// <summary>
+        /// Set an identifier for your query. You don't need to set this, it's intended to allow you to link an <see cref="IGraphClient.OperationCompleted"/> event to a specific query.
+        /// </summary>
+        /// <param name="identifier">An ID you want to use to differentiate the query. If this is <c>null</c> or whitespace - it will be set to <c>null</c>.</param>
+        /// <returns>An <see cref="ICypherFluentQuery"/> to query with.</returns>
+        ICypherFluentQuery WithIdentifier(string identifier);
+
+        /// <summary>
+        /// Perform the query using the given <paramref name="bookmarks"/>.
+        /// </summary>
+        /// <remarks>This only works for a <strong>Bolt</strong> session.</remarks>
+        /// <param name="bookmark">The bookmark to use.</param>
+        /// <returns>A <see cref="ICypherFluentQuery"/> instance to continue querying with.</returns>
+        ICypherFluentQuery WithBookmark(string bookmark);
+
+        /// <summary>
+        /// Perform the query using the given <paramref name="bookmarks"/>.
+        /// </summary>
+        /// <remarks>This only works for a <strong>Bolt</strong> session.</remarks>
+        /// <param name="bookmarks">The bookmarks to use.</param>
+        /// <returns>A <see cref="ICypherFluentQuery"/> instance to continue querying with.</returns>
+        ICypherFluentQuery WithBookmarks(params string[] bookmarks);
     }
 }

--- a/Neo4jClient.Shared/Cypher/QueryWriter.cs
+++ b/Neo4jClient.Shared/Cypher/QueryWriter.cs
@@ -13,7 +13,8 @@ namespace Neo4jClient.Cypher
         readonly IDictionary<string, object> queryParameters;
         CypherResultMode resultMode;
         private CypherResultFormat resultFormat;
-
+        private readonly List<string> bookmarks = new List<string>();
+    
         public QueryWriter()
         {
             queryTextBuilder = new StringBuilder();
@@ -26,35 +27,44 @@ namespace Neo4jClient.Cypher
             StringBuilder queryTextBuilder,
             IDictionary<string, object> queryParameters,
             CypherResultMode resultMode,
-            CypherResultFormat resultFormat)
+            CypherResultFormat resultFormat,
+            List<string> bookmarks,
+            string identifier)
         {
             this.queryTextBuilder = queryTextBuilder;
             this.queryParameters = queryParameters;
             this.resultMode = resultMode;
             this.resultFormat = resultFormat;
+            this.Identifier = identifier;
+            this.bookmarks = bookmarks;
         }
+
+        public List<string> Bookmarks => bookmarks;
 
         public CypherResultMode ResultMode
         {
-            get { return resultMode; }
-            set { resultMode = value; }
+            get => resultMode;
+            set => resultMode = value;
         }
 
         public CypherResultFormat ResultFormat
         {
-            get { return resultFormat; }
-            set { resultFormat = value; }
+            get => resultFormat;
+            set => resultFormat = value;
         }
 
         public int? MaxExecutionTime { get; set; }
 
         public NameValueCollection CustomHeaders { get; set; }
+        public string Identifier { get; set; }
 
         public QueryWriter Clone()
         {
             var clonedQueryTextBuilder = new StringBuilder(queryTextBuilder.ToString());
             var clonedParameters = new Dictionary<string, object>(queryParameters);
-            return new QueryWriter(clonedQueryTextBuilder, clonedParameters, resultMode, resultFormat)
+            var clonedBookmarks = new List<string>(bookmarks);
+            
+            return new QueryWriter(clonedQueryTextBuilder, clonedParameters, resultMode, resultFormat, clonedBookmarks, Identifier)
             {
                 MaxExecutionTime = MaxExecutionTime,
                 CustomHeaders = CustomHeaders
@@ -75,7 +85,9 @@ namespace Neo4jClient.Cypher
 				contractResolver,
                 MaxExecutionTime,
                 CustomHeaders,
-                isWrite
+                isWrite,
+                Bookmarks,
+                Identifier
                 );
         }
 

--- a/Neo4jClient.Shared/GraphClient.cs
+++ b/Neo4jClient.Shared/GraphClient.cs
@@ -741,10 +741,30 @@ namespace Neo4jClient
 
         public ITransaction BeginTransaction()
         {
-            return BeginTransaction(TransactionScopeOption.Join);
+            return BeginTransaction((IEnumerable<string>) null);
+        }
+
+        public ITransaction BeginTransaction(string bookmark)
+        {
+            return BeginTransaction(new List<string> {bookmark});
+        }
+
+        public ITransaction BeginTransaction(IEnumerable<string> bookmarks)
+        {
+            return BeginTransaction(TransactionScopeOption.Join, bookmarks);
         }
 
         public ITransaction BeginTransaction(TransactionScopeOption scopeOption)
+        {
+            return BeginTransaction(scopeOption, (IEnumerable<string>) null);
+        }
+
+        public ITransaction BeginTransaction(TransactionScopeOption scopeOption, string bookmark)
+        {
+            return BeginTransaction(scopeOption, new List<string>{bookmark});
+        }
+
+        public ITransaction BeginTransaction(TransactionScopeOption scopeOption, IEnumerable<string> bookmarks)
         {
             CheckRoot();
             if (transactionManager == null)
@@ -752,7 +772,7 @@ namespace Neo4jClient
                 throw new NotSupportedException("HTTP Transactions are only supported on Neo4j 2.0 and newer.");
             }
 
-            return transactionManager.BeginTransaction(scopeOption);
+            return transactionManager.BeginTransaction(scopeOption, bookmarks);
         }
 
         public ITransaction Transaction => transactionManager?.CurrentNonDtcTransaction;

--- a/Neo4jClient.Shared/Neo4jClient.Shared.projitems
+++ b/Neo4jClient.Shared/Neo4jClient.Shared.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQuery`Return.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQuery`TResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQuery`Where.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQuery`WithBookmark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQuery`With.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherPlanner.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherQuery.cs" />

--- a/Neo4jClient.Shared/Neo4jDriverExtensions.cs
+++ b/Neo4jClient.Shared/Neo4jDriverExtensions.cs
@@ -19,7 +19,6 @@ namespace Neo4jClient
         
         public static IStatementResult Run(this ISession session, CypherQuery query, IGraphClient gc)
         {
-            
             return session.Run(query.QueryText, query.ToNeo4jDriverParameters(gc));
         }
 
@@ -82,7 +81,7 @@ namespace Neo4jClient
                 .Where(pi => !(pi.GetIndexParameters().Any() || pi.IsDefined(typeof(JsonIgnoreAttribute))))
                 .ToDictionary(pi => pi.Name, pi => Serialize(pi.GetValue(value), converters, gc));
         }
-
+        
         private static object SerializeCollection(IEnumerable value, IList<JsonConverter> converters, IGraphClient gc)
         {
             return value.Cast<object>().Select(x => Serialize(x, converters, gc)).ToArray();

--- a/Neo4jClient.Shared/OperationCompletedEventHandler.cs
+++ b/Neo4jClient.Shared/OperationCompletedEventHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 
 namespace Neo4jClient
@@ -7,6 +8,8 @@ namespace Neo4jClient
 
     public class OperationCompletedEventArgs : EventArgs
     {
+        public string Identifier { get; set; }
+        public string LastBookmark { get; set; }
         public string QueryText { get; set; }
         public int ResourcesReturned { get; set; }
         public TimeSpan TimeTaken { get; set; }
@@ -14,10 +17,11 @@ namespace Neo4jClient
         public bool HasException { get { return Exception != null; } }
         public int? MaxExecutionTime { get; set; }
         public NameValueCollection CustomHeaders { get; set; }
+        public IEnumerable<string> BookmarksUsed { get; set; }
 
         public override string ToString()
         {
-            return string.Format("HasException={0}, QueryText={1}", HasException, QueryText);
+            return $"HasException={HasException}, QueryText={QueryText}";
         }
     }
 }

--- a/Neo4jClient.Shared/Transactions/ITransactionManager.cs
+++ b/Neo4jClient.Shared/Transactions/ITransactionManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Neo4jClient.Cypher;
@@ -14,7 +15,7 @@ namespace Neo4jClient.Transactions
         bool InTransaction { get; }
         ITransaction CurrentNonDtcTransaction { get; }
         ITransaction CurrentDtcTransaction { get; }
-        ITransaction BeginTransaction(TransactionScopeOption option);
+        ITransaction BeginTransaction(TransactionScopeOption option, IEnumerable<string> bookmarks);
         void EndTransaction();
         void RegisterToTransactionIfNeeded();
         Task<T> EnqueueCypherRequest(string commandDescription, IGraphClient graphClient, CypherQuery query);

--- a/Neo4jClient.Shared/Transactions/ITransactionalGraphClient.cs
+++ b/Neo4jClient.Shared/Transactions/ITransactionalGraphClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Neo4jClient.Transactions
 {
@@ -32,11 +33,39 @@ namespace Neo4jClient.Transactions
         ITransaction BeginTransaction();
 
         /// <summary>
-        /// Scopes the next cypher queries within a transaction (or supress it), according to a given scope option.
+        /// Scopes the next cypher queries within a transaction, or joins an existing one.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be used when executing multiple Cypher queries
+        /// in multiple HTTP requests. Neo4j already encapsulates a single Cypher request within its
+        /// own transaction.
+        /// 
+        /// The transaction object created is thread static, that is, that the following queries will only be within
+        /// a transaction for the current thread.
+        /// </remarks>
+        /// <param name="bookmark">The bookmark to use for this transaction.</param>
+        ITransaction BeginTransaction(string bookmark);
+
+        /// <summary>
+        /// Scopes the next cypher queries within a transaction, or joins an existing one.
+        /// </summary>
+        /// <remarks>
+        /// This method should only be used when executing multiple Cypher queries
+        /// in multiple HTTP requests. Neo4j already encapsulates a single Cypher request within its
+        /// own transaction.
+        /// 
+        /// The transaction object created is thread static, that is, that the following queries will only be within
+        /// a transaction for the current thread.
+        /// </remarks>
+        /// <param name="bookmarks">The bookmarks to use for this transaction.</param>
+        ITransaction BeginTransaction(IEnumerable<string> bookmarks);
+
+        /// <summary>
+        /// Scopes the next cypher queries within a transaction (or suppress it), according to a given scope option.
         /// </summary>
         /// <remarks>
         /// This method should be used when executing multiple Cypher queries in multiple HTTP requests,
-        /// or when the thread is already under a transaction and the programmer wishes to temporarily supress it.
+        /// or when the thread is already under a transaction and the programmer wishes to temporarily suppress it.
         /// 
         /// It should not be called to execute a single Cypher query as it will only add latency to the process. Neo4j already encapsulates
         /// a single Cypher request within its own transaction.
@@ -71,6 +100,90 @@ namespace Neo4jClient.Transactions
         /// </list>
         /// </param>
         ITransaction BeginTransaction(TransactionScopeOption scopeOption);
+
+        /// <summary>
+        /// Scopes the next cypher queries within a transaction (or suppress it), according to a given scope option.
+        /// </summary>
+        /// <remarks>
+        /// This method should be used when executing multiple Cypher queries in multiple HTTP requests,
+        /// or when the thread is already under a transaction and the programmer wishes to temporarily suppress it.
+        /// 
+        /// It should not be called to execute a single Cypher query as it will only add latency to the process. Neo4j already encapsulates
+        /// a single Cypher request within its own transaction.
+        /// 
+        /// Be aware that joining a nested transaction must be done before the parent scope completes either by committing or rolling back,
+        /// otherwise it will throw an InvalidOperationException.
+        /// 
+        /// The transaction object created is thread static, that is, that the following queries will only be within
+        /// a transaction for the current thread.
+        /// </remarks>
+        /// <param name="scopeOption">
+        /// 
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term>Join</term>
+        ///         <description>Creates a new transaction, or joins an existing one. This the default value.
+        ///         The transaction commits until all the scope that have a reference to it commit. However, the transaction rolls back 
+        ///         on the first call to Rollback().</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>RequiresNew</term>
+        ///         <description>The method will generate a new transaction. It is important to notice that this new transaction is not
+        /// related to an existent parent transaction scope. Committing or rolling back either one has no effect on the other.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Suppress</term>
+        ///         <description>The statements that are executed under this scope, will not be executed under the transaction.
+        ///         Committing or rolling back generates an <c>InvalidOperationException</c>. Creating a new transaction scope with Join under
+        ///         a suppressed one, will be the same as RequiresNew.</description>
+        ///     </item>
+        /// </list>
+        /// </param>
+        /// <param name="bookmark">The bookmark to use for this transaction.</param>
+        ITransaction BeginTransaction(TransactionScopeOption scopeOption, string bookmark);
+
+        /// <summary>
+        /// Scopes the next cypher queries within a transaction (or suppress it), according to a given scope option.
+        /// </summary>
+        /// <remarks>
+        /// This method should be used when executing multiple Cypher queries in multiple HTTP requests,
+        /// or when the thread is already under a transaction and the programmer wishes to temporarily suppress it.
+        /// 
+        /// It should not be called to execute a single Cypher query as it will only add latency to the process. Neo4j already encapsulates
+        /// a single Cypher request within its own transaction.
+        /// 
+        /// Be aware that joining a nested transaction must be done before the parent scope completes either by committing or rolling back,
+        /// otherwise it will throw an InvalidOperationException.
+        /// 
+        /// The transaction object created is thread static, that is, that the following queries will only be within
+        /// a transaction for the current thread.
+        /// </remarks>
+        /// <param name="scopeOption">
+        /// 
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term>Join</term>
+        ///         <description>Creates a new transaction, or joins an existing one. This the default value.
+        ///         The transaction commits until all the scope that have a reference to it commit. However, the transaction rolls back 
+        ///         on the first call to Rollback().</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>RequiresNew</term>
+        ///         <description>The method will generate a new transaction. It is important to notice that this new transaction is not
+        /// related to an existent parent transaction scope. Committing or rolling back either one has no effect on the other.
+        ///         </description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Suppress</term>
+        ///         <description>The statements that are executed under this scope, will not be executed under the transaction.
+        ///         Committing or rolling back generates an <c>InvalidOperationException</c>. Creating a new transaction scope with Join under
+        ///         a suppressed one, will be the same as RequiresNew.</description>
+        ///     </item>
+        /// </list>
+        /// </param>
+        /// <param name="bookmarks">The bookmarks to use for this transaction.</param>
+        ITransaction BeginTransaction(TransactionScopeOption scopeOption, IEnumerable<string> bookmark);
 
         /// <summary>
         /// The current transaction object.

--- a/Neo4jClient.Tests.Shared/BoltGraphClientTests/Bookmarks/BookmarkTests.cs
+++ b/Neo4jClient.Tests.Shared/BoltGraphClientTests/Bookmarks/BookmarkTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using Neo4j.Driver.V1;
+using Neo4jClient.Cypher;
+using Neo4jClient.Test.BoltGraphClientTests.Cypher;
+using Neo4jClient.Test.Fixtures;
+using Neo4jClient.Transactions;
+using Xunit;
+
+namespace Neo4jClient.Test.BoltGraphClientTests
+{
+    public class BookmarkTests : IClassFixture<CultureInfoSetupFixture>
+    {
+        public class OperationCompletedEvent : IClassFixture<CultureInfoSetupFixture>
+        {
+            private class ObjectWithIds
+            {
+                public List<int> Ids { get; set; }
+            }
+
+            [Fact]
+            public void ArgsContainBookmarksUsed()
+            {
+                // Arrange
+                var bookmarks = new List<string> {"Bookmark1", "Bookmark2"};
+
+                const string queryText = "RETURN [] AS data";
+
+                var queryParams = new Dictionary<string, object>();
+
+                var cypherQuery = new CypherQuery(queryText, queryParams, CypherResultMode.Set, CypherResultFormat.Transactional) {Bookmarks = bookmarks};
+
+                using (var testHarness = new BoltTestHarness())
+                {
+                    var recordMock = new Mock<IRecord>();
+                    recordMock.Setup(r => r["data"]).Returns(new List<INode>());
+                    recordMock.Setup(r => r.Keys).Returns(new[] {"data"});
+
+                    var testStatementResult = new TestStatementResult(new[] {"data"}, recordMock.Object);
+                    testHarness.SetupCypherRequestResponse(cypherQuery.QueryText, cypherQuery.QueryParameters, testStatementResult);
+
+                    var graphClient = testHarness.CreateAndConnectBoltGraphClient();
+                    graphClient.OperationCompleted += (s, e) =>
+                    {
+                        e.BookmarksUsed.Should().Contain(bookmarks[0]);
+                        e.BookmarksUsed.Should().Contain(bookmarks[1]);
+                    };
+
+                    graphClient.ExecuteGetCypherResults<IEnumerable<ObjectWithIds>>(cypherQuery);
+                }
+            }
+
+
+            [Fact]
+            public void ArgsContainBookmarkUsed()
+            {
+                // Arrange
+                const string bookmark = "Bookmark1";
+                var bookmarks = new List<string> {bookmark};
+
+                const string queryText = "RETURN [] AS data";
+
+                var queryParams = new Dictionary<string, object>();
+
+                var cypherQuery = new CypherQuery(queryText, queryParams, CypherResultMode.Set, CypherResultFormat.Transactional) {Bookmarks = bookmarks};
+
+                using (var testHarness = new BoltTestHarness())
+                {
+                    var recordMock = new Mock<IRecord>();
+                    recordMock.Setup(r => r["data"]).Returns(new List<INode>());
+                    recordMock.Setup(r => r.Keys).Returns(new[] {"data"});
+
+                    var testStatementResult = new TestStatementResult(new[] {"data"}, recordMock.Object);
+                    testHarness.SetupCypherRequestResponse(cypherQuery.QueryText, cypherQuery.QueryParameters, testStatementResult);
+
+                    var graphClient = testHarness.CreateAndConnectBoltGraphClient();
+                    graphClient.OperationCompleted += (s, e) => { e.BookmarksUsed.Should().Contain(bookmarks[0]); };
+
+                    graphClient.ExecuteGetCypherResults<IEnumerable<ObjectWithIds>>(cypherQuery);
+                }
+            }
+
+            [Fact]
+            public void ArgsContainLastBookmark()
+            {
+                const string lastBookmark = "LastBookmark";
+
+                const string queryText = "RETURN [] AS data";
+
+                var queryParams = new Dictionary<string, object>();
+
+                var cypherQuery = new CypherQuery(queryText, queryParams, CypherResultMode.Set, CypherResultFormat.Transactional);
+
+                using (var testHarness = new BoltTestHarness())
+                {
+                    var recordMock = new Mock<IRecord>();
+                    recordMock.Setup(r => r["data"]).Returns(new List<INode>());
+                    recordMock.Setup(r => r.Keys).Returns(new[] {"data"});
+
+                    testHarness.MockSession.Setup(s => s.LastBookmark).Returns(lastBookmark);
+
+                    var testStatementResult = new TestStatementResult(new[] {"data"}, recordMock.Object);
+                    testHarness.SetupCypherRequestResponse(cypherQuery.QueryText, cypherQuery.QueryParameters, testStatementResult);
+
+                    var graphClient = testHarness.CreateAndConnectBoltGraphClient();
+                    graphClient.OperationCompleted += (s, e) => { e.LastBookmark.Should().Be(lastBookmark); };
+
+                    graphClient.ExecuteGetCypherResults<IEnumerable<ObjectWithIds>>(cypherQuery);
+                }
+            }
+
+            [Fact]
+            public void SessionIsCalledWithBookmark()
+            {
+                // Arrange
+                const string bookmark = "Bookmark1";
+
+                var cypherQuery = new CypherQuery("RETURN 1", new Dictionary<string, object>(), CypherResultMode.Projection, CypherResultFormat.Transactional) {Bookmarks = new List<string> {bookmark}};
+
+                using (var testHarness = new BoltTestHarness())
+                {
+                    try
+                    {
+                        testHarness.CreateAndConnectBoltGraphClient().ExecuteGetCypherResults<object>(cypherQuery).ToArray();
+                    }
+                    catch
+                    {
+                        /*Not interested in actually getting results*/
+                    }
+
+                    //Assert
+                    testHarness.MockDriver.Verify(d => d.Session(It.IsAny<AccessMode>(), It.Is<IEnumerable<string>>(s => s.Contains(bookmark))), Times.Once);
+                }
+            }
+
+            [Fact]
+            public void SessionIsCalledWithBookmarks()
+            {
+                // Arrange
+                var bookmarks = new List<string> {"Bookmark1", "Bookmark2"};
+
+                var cypherQuery = new CypherQuery("RETURN 1", new Dictionary<string, object>(), CypherResultMode.Projection, CypherResultFormat.Transactional) {Bookmarks = bookmarks};
+
+                using (var testHarness = new BoltTestHarness())
+                {
+                    try
+                    {
+                        testHarness.CreateAndConnectBoltGraphClient().ExecuteGetCypherResults<object>(cypherQuery).ToArray();
+                    }
+                    catch
+                    {
+                        /*Not interested in actually getting results*/
+                    }
+
+                    //Assert
+                    testHarness.MockDriver.Verify(d => d.Session(It.IsAny<AccessMode>(), It.Is<IEnumerable<string>>(s => s.Contains(bookmarks[0]) && s.Contains(bookmarks[1]))), Times.Once);
+                }
+            }
+
+            [Fact]
+            public void TransactionIsCalledWithBookmark()
+            {
+                // Arrange
+                const string bookmark = "Bookmark1";
+                var bookmarks = new List<string> {bookmark};
+
+                using (var testHarness = new BoltTestHarness())
+                {
+                    var gc = testHarness.CreateAndConnectBoltGraphClient() as ITransactionalGraphClient;
+                    gc.BeginTransaction(bookmarks);
+
+                    //Assert
+                    testHarness.MockDriver.Verify(d => d.Session(It.Is<IEnumerable<string>>(s => s.Contains(bookmark))), Times.Once);
+                }
+            }
+
+            [Fact]
+            public void TransactionIsCalledWithBookmarks()
+            {
+                // Arrange
+                var bookmarks = new List<string> {"Bookmark1", "Bookmark2"};
+
+                using (var testHarness = new BoltTestHarness())
+                {
+                    var gc = testHarness.CreateAndConnectBoltGraphClient() as ITransactionalGraphClient;
+                    gc.BeginTransaction(bookmarks);
+
+                    //Assert
+                    testHarness.MockDriver.Verify(d => d.Session(It.Is<IEnumerable<string>>(s => s.Contains(bookmarks[0]) && s.Contains(bookmarks[1]))), Times.Once);
+                }
+            }
+        }
+    }
+}

--- a/Neo4jClient.Tests.Shared/BoltGraphClientTests/Cypher/ExecuteGetCypherResultsTests.cs
+++ b/Neo4jClient.Tests.Shared/BoltGraphClientTests/Cypher/ExecuteGetCypherResultsTests.cs
@@ -12,38 +12,6 @@ using Xunit;
 
 namespace Neo4jClient.Test.BoltGraphClientTests.Cypher
 {
-    public class BoltTestHarness : IDisposable
-    {
-        private readonly Mock<IDriver> mockDriver = new Mock<IDriver>();
-        private readonly Mock<ISession> mockSession = new Mock<ISession>();
-
-        public BoltTestHarness()
-        {
-            mockSession.Setup(s => s.Run("CALL dbms.components()")).Returns(new Extensions.BoltGraphClientTests.ServerInfo());
-            mockDriver.Setup(d => d.Session(It.IsAny<AccessMode>())).Returns(mockSession.Object);
-            
-            mockDriver.Setup(d => d.Uri).Returns(new Uri("bolt://localhost"));
-        }
-
-        public void Dispose()
-        {
-        }
-
-        public void SetupCypherRequestResponse(string request, IDictionary<string, object> cypherQueryQueryParameters, IStatementResult response)
-        {
-            mockSession.Setup(s => s.Run(request, It.IsAny<IDictionary<string, object>>())).Returns(response);
-        }
-
-        public IRawGraphClient CreateAndConnectBoltGraphClient()
-        {
-            var bgc = new BoltGraphClient(mockDriver.Object);
-            bgc.Connect();
-            return bgc;
-        }
-
-        
-    }
-
     internal class TestPath : IPath
     {
         #region Implementation of IEquatable<IPath>
@@ -200,7 +168,7 @@ namespace Neo4jClient.Test.BoltGraphClientTests.Cypher
                 var results = graphClient.ExecuteGetCypherResults<RelationGrouper>(cypherQuery).ToArray();
 
                 //Assert
-                Assert.Equal(1, results.Length);
+                results.Length.Should().Be(1);
                 var relation = results.First().Rel;
                 relation.Id.Should().Be(42);
             }

--- a/Neo4jClient.Tests.Shared/BoltTestHarness.cs
+++ b/Neo4jClient.Tests.Shared/BoltTestHarness.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Moq;
+using Neo4j.Driver.V1;
+
+namespace Neo4jClient.Test
+{
+    public class BoltTestHarness : IDisposable
+    {
+        public BoltTestHarness()
+        {
+            MockSession.Setup(s => s.Run("CALL dbms.components()")).Returns(new Extensions.BoltGraphClientTests.ServerInfo());
+            MockDriver.Setup(d => d.Session(It.IsAny<AccessMode>())).Returns(MockSession.Object);
+            MockDriver.Setup(d => d.Session(It.IsAny<AccessMode>(), It.IsAny<IEnumerable<string>>())).Returns(MockSession.Object);
+            MockDriver.Setup(d => d.Session(It.IsAny<IEnumerable<string>>())).Returns(MockSession.Object);
+            MockDriver.Setup(d => d.Uri).Returns(new Uri("bolt://localhost"));
+        }
+
+        public Mock<IDriver> MockDriver { get; } = new Mock<IDriver>();
+        public Mock<ISession> MockSession { get; } = new Mock<ISession>();
+
+        public void Dispose()
+        {
+        }
+
+        public void SetupCypherRequestResponse(string request, IDictionary<string, object> cypherQueryQueryParameters, IStatementResult response)
+        {
+            MockSession.Setup(s => s.Run(request, It.IsAny<IDictionary<string, object>>())).Returns(response);
+            MockSession.Setup(s => s.WriteTransaction(It.IsAny<Func<ITransaction, IStatementResult>>())).Returns(response);
+        }
+
+        public IRawGraphClient CreateAndConnectBoltGraphClient()
+        {
+            var bgc = new BoltGraphClient(MockDriver.Object);
+            bgc.Connect();
+            return bgc;
+        }
+    }
+}

--- a/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWithBookmarkTests.cs
+++ b/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWithBookmarkTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NSubstitute;
+using Xunit;
+using Neo4jClient.Cypher;
+using Neo4jClient.Test.Fixtures;
+
+namespace Neo4jClient.Test.Cypher
+{
+    public class WithBookmarkMethod : IClassFixture<CultureInfoSetupFixture>
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData(null)]
+        public void DoesNothing_WhenBookmarkIsWhitespaceOrNull(string bookmark)
+        {
+            var mockGc = new Mock<IRawGraphClient>();
+
+            var cfq = new CypherFluentQuery(mockGc.Object);
+            cfq.WithBookmark(bookmark);
+            var query = cfq.Query;
+
+            query.Bookmarks.Should().HaveCount(0);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData(null)]
+        public void DoesNothing_WhenBookmarkIsWhitespaceOrNull_ForBookmarks(string bookmark)
+        {
+            var mockGc = new Mock<IRawGraphClient>();
+            var list = new List<string> { bookmark };
+            var cfq = new CypherFluentQuery(mockGc.Object);
+            cfq.WithBookmarks(list.ToArray());
+            var query = cfq.Query;
+
+            query.Bookmarks.Should().HaveCount(0);
+        }
+
+        [Fact]
+        public void SetsBookmark_InQuery()
+        {
+            const string bookmarkName = "Bookmark1";
+            var mockGc = new Mock<IRawGraphClient>();
+
+            var cfq = new CypherFluentQuery(mockGc.Object);
+            cfq.WithBookmark(bookmarkName);
+            var query = cfq.Query;
+
+            query.Bookmarks.Should().HaveCount(1);
+            query.Bookmarks.Should().Contain(bookmarkName);
+        }
+
+        [Fact]
+        public void SetsBookmarks_InQuery1()
+        {
+            const string bookmarkName1 = "Bookmark1";
+            const string bookmarkName2 = "Bookmark2";
+            var mockGc = new Mock<IRawGraphClient>();
+
+            var cfq = new CypherFluentQuery(mockGc.Object);
+            cfq.WithBookmarks(bookmarkName1, bookmarkName2);
+            var query = cfq.Query;
+
+            query.Bookmarks.Should().HaveCount(2);
+            query.Bookmarks.Should().Contain(bookmarkName1);
+            query.Bookmarks.Should().Contain(bookmarkName2);
+        }
+
+        [Fact]
+        public void SetsBookmarks_InQuery2()
+        {
+            const string bookmarkName1 = "Bookmark1";
+            const string bookmarkName2 = "Bookmark2";
+            var list = new List<string> { bookmarkName1, bookmarkName2 };
+            var mockGc = new Mock<IRawGraphClient>();
+
+            var cfq = new CypherFluentQuery(mockGc.Object);
+            cfq.WithBookmarks(list.ToArray());
+            var query = cfq.Query;
+
+            query.Bookmarks.Should().HaveCount(2);
+            query.Bookmarks.Should().Contain(bookmarkName1);
+            query.Bookmarks.Should().Contain(bookmarkName2);
+        }
+    }
+}

--- a/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWithIdentifierTests.cs
+++ b/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWithIdentifierTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using Neo4j.Driver.V1;
+using Neo4jClient.Cypher;
+using Neo4jClient.Test.BoltGraphClientTests;
+using Neo4jClient.Test.BoltGraphClientTests.Cypher;
+using Neo4jClient.Test.Fixtures;
+using Xunit;
+
+namespace Neo4jClient.Test.Cypher
+{
+    public class WithIdentifierMethod : IClassFixture<CultureInfoSetupFixture>
+    {
+        private class ObjectWithIds
+        {
+            public List<int> Ids { get; set; }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData(null)]
+        public void DoesNothing_WhenIdentifierIsNullOrWhitespace(string identifier)
+        {
+            var mockGc = new Mock<IRawGraphClient>();
+
+            var cfq = new CypherFluentQuery(mockGc.Object);
+            cfq.WithIdentifier(identifier);
+            var query = cfq.Query;
+            query.Identifier.Should().BeNull();
+        }
+
+        [Fact]
+        public void SetsTheIdentifer_WhenValid()
+        {
+            const string identifier = "MyQuery";
+            var mockGc = new Mock<IRawGraphClient>();
+
+            var cfq = new CypherFluentQuery(mockGc.Object);
+            cfq.WithIdentifier(identifier);
+            var query = cfq.Query;
+            query.Identifier.Should().Be(identifier);
+        }
+
+        [Fact]
+        public void ArgsContainIdentifier()
+        {
+            const string identifier = "identifier";
+
+            const string queryText = "RETURN [] AS data";
+
+            var queryParams = new Dictionary<string, object>();
+
+            var cypherQuery = new CypherQuery(queryText, queryParams, CypherResultMode.Set, CypherResultFormat.Transactional){Identifier = identifier};
+
+            using (var testHarness = new BoltTestHarness())
+            {
+                var recordMock = new Mock<IRecord>();
+                recordMock.Setup(r => r["data"]).Returns(new List<INode>());
+                recordMock.Setup(r => r.Keys).Returns(new[] { "data" });
+
+                var testStatementResult = new TestStatementResult(new[] { "data" }, recordMock.Object);
+                testHarness.SetupCypherRequestResponse(cypherQuery.QueryText, cypherQuery.QueryParameters, testStatementResult);
+
+                var graphClient = testHarness.CreateAndConnectBoltGraphClient();
+                graphClient.OperationCompleted += (s, e) => { e.Identifier.Should().Be(identifier); };
+
+                graphClient.ExecuteGetCypherResults<IEnumerable<ObjectWithIds>>(cypherQuery);
+            }
+        }
+
+    }
+}

--- a/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
+++ b/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
@@ -12,7 +12,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\GremlinTableCapResponseTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\RootApiResponseTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiUsageIdeas.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)BoltGraphClientTests\Bookmarks\BookmarkTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BoltGraphClientTests\ConnectAsyncTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)BoltTestHarness.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BoltGraphClientTests\Cypher\ExecuteGetCypherResultsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CultureInfoSetupFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\AggregateTests.cs" />
@@ -20,6 +22,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryCallTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryConstraintTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryCreateUniqueTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryWithIdentifierTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryWithBookmarkTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryReadWriteTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryDeleteTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\CypherFluentQueryDetachDeleteTests.cs" />

--- a/Neo4jClient.Tests/Transactions/BoltQueriesInTransactionTests.cs
+++ b/Neo4jClient.Tests/Transactions/BoltQueriesInTransactionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Transactions;
@@ -52,10 +53,12 @@ namespace Neo4jClient.Test.Transactions
             var dbmsReturn = GetDbmsComponentsResponse();
             mockSession.Run("CALL dbms.components()").Returns(dbmsReturn);
             mockSession.BeginTransaction().Returns(mockTransaction);
-
+            
             var mockDriver = Substitute.For<IDriver>();
             mockDriver.Session().Returns(mockSession);
             mockDriver.Session(Arg.Any<AccessMode>()).Returns(mockSession);
+            mockDriver.Session(Arg.Any<AccessMode>(), Arg.Any<IEnumerable<string>>()).Returns(mockSession);
+            mockDriver.Session(Arg.Any<IEnumerable<string>>()).Returns(mockSession);
             mockDriver.Uri.Returns(new Uri("bolt://localhost"));
 
             driver = mockDriver;
@@ -93,7 +96,7 @@ namespace Neo4jClient.Test.Transactions
                 var rawGraphClient = (IRawGraphClient) graphClient;
                 rawGraphClient.ExecuteMultipleCypherQueriesInTransaction(new[]{query});
 
-                driver.Received(1).Session();
+                driver.Received(1).Session((IEnumerable<string>) null);
                 session.Received(1).BeginTransaction();
                 transaction.Received(1).Success();
             }
@@ -115,7 +118,7 @@ namespace Neo4jClient.Test.Transactions
                     tx.Commit();
                 }
 
-                driver.Received(1).Session();
+                driver.Received(1).Session((IEnumerable<string>)null);
                 session.Received(1).BeginTransaction();
                 transaction.Received(1).Success();
             }
@@ -145,7 +148,7 @@ namespace Neo4jClient.Test.Transactions
                     tx.Commit();
                 }
 
-                driver.Received(1).Session();
+                driver.Received(1).Session((IEnumerable<string>) null);
                 session.Received(1).BeginTransaction();
                 transaction.Received(1).Success();
             }
@@ -182,7 +185,7 @@ namespace Neo4jClient.Test.Transactions
                         .ExecuteWithoutResults();
                 }
 
-                driver.Received(1).Session(Arg.Any<AccessMode>());
+                driver.Received(1).Session(Arg.Any<AccessMode>(),(IEnumerable<string>) null);
                 transaction.Received(1).Failure();
                 transaction.Received(1).Dispose();
             }
@@ -203,7 +206,7 @@ namespace Neo4jClient.Test.Transactions
                     scope.Complete();
                 }
 
-                driver.Received(1).Session(Arg.Any<AccessMode>());
+                driver.Received(1).Session(Arg.Any<AccessMode>(), (IEnumerable<string>)null);
                 session.Received(1).BeginTransaction();
                 transaction.Received(1).Run(Arg.Any<string>(), Arg.Any<Dictionary<string, object>>());
                 transaction.Received(1).Success();
@@ -228,7 +231,7 @@ namespace Neo4jClient.Test.Transactions
                     scope.Complete();
                 }
 
-                driver.Received(1).Session(Arg.Any<AccessMode>());
+                driver.Received(1).Session(Arg.Any<AccessMode>(), (IEnumerable<string>)null);
                 session.Received(1).BeginTransaction();
                 transaction.Received(1).Success();
                 transaction.Received(1).Dispose();
@@ -259,7 +262,7 @@ namespace Neo4jClient.Test.Transactions
                     scope.Complete();
                 }
 
-                driver.Received(2).Session(Arg.Any<AccessMode>());
+                driver.Received(2).Session(Arg.Any<AccessMode>(), (IEnumerable<string>)null);
                 session.Received(2).BeginTransaction();
                 transaction.Received(2).Success();
                 transaction.Received(2).Dispose();
@@ -292,7 +295,7 @@ namespace Neo4jClient.Test.Transactions
                     scope.Complete();
                 }
 
-                driver.Received(2).Session(Arg.Any<AccessMode>());
+                driver.Received(2).Session(Arg.Any<AccessMode>(), (IEnumerable<string>)null);
                 session.Received(2).BeginTransaction();
                 transaction.Received(2).Success();
                 transaction.Received(2).Dispose();
@@ -315,7 +318,7 @@ namespace Neo4jClient.Test.Transactions
                     graphClient.Cypher.Match("(n)").Set("n.Value = 'test'").ExecuteWithoutResults();
                 }
 
-                driver.Received(1).Session(Arg.Any<AccessMode>());
+                driver.Received(1).Session(Arg.Any<AccessMode>(), (IEnumerable<string>)null);
                 transaction.Received(1).Failure();
             }
         }


### PR DESCRIPTION
Adds 3 new methods to the `Cypher` fluent query:
* `.WithIdentifier(string)` - which allows you to specifiy an identifier for a query
* `.WithBookmark(string)` - which allows you to execute a query with a specific bookmark
* `.WithBookmarks(params string[])` - Which allows you to execute a query with multiple bookmarks

Changed `OperationCompletedEventArgs` to contain 3 new properties:
* `.LastBookmark` - the last bookmark from the Bolt query
* `.BookmarksUsed` - a list of the bookmarks passed in for the query
* `.Identifier` - the identifier set using `WithIdentifier`

`null` or whitespace to any of these will be ignored, and by default they are all null.