### PR TITLE
Added support for multiple URIs in the constructor for BoltGraphClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ TestResult.xml
 \.idea/
 *\.vs\*
 *.nuget.targets
+
+Neo4jClient/Neo4jClient\.nuget\.props

--- a/Neo4jClient.Full.Shared/BoltGraphClient.cs
+++ b/Neo4jClient.Full.Shared/BoltGraphClient.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Neo4j.Driver.V1;
 using Neo4jClient.Execution;
-using Neo4jClient.Serialization;
 using Neo4jClient.Transactions;
 using Newtonsoft.Json;
 
@@ -15,11 +15,34 @@ namespace Neo4jClient
 {
     public partial class BoltGraphClient : IBoltGraphClient, IRawGraphClient, ITransactionalGraphClient
     {
-        public BoltGraphClient(Uri uri, string username = null, string password = null, string realm = null)
+        /// <summary>
+        ///     Creates a new instance of the <see cref="BoltGraphClient" />.
+        /// </summary>
+        /// <param name="uri">
+        ///     If the <paramref name="uris" /> parameter is provided, this will be treated as a <em>virtual URI</em>
+        ///     , else it will be the URI connected to.
+        /// </param>
+        /// <param name="uris">
+        ///     A collection of <see cref="Uri" /> instances to connect to using an
+        ///     <see cref="IServerAddressResolver" />. Leave <c>null</c> (or empty) if you don't want to use it.
+        /// </param>
+        /// <param name="username">The username to connect to Neo4j with.</param>
+        /// <param name="password">The password to connect to Neo4j with.</param>
+        /// <param name="realm">The realm to connect to Neo4j with.</param>
+        public BoltGraphClient(Uri uri, IEnumerable<Uri> uris, string username = null, string password = null, string realm = null)
         {
-            if ((uri.Scheme == "http") || (uri.Scheme == "https"))
-                throw new NotSupportedException($"To use the {nameof(BoltGraphClient)} you need to provide a 'bolt://' scheme, not '{uri.Scheme}'.");
+            var localUris = uris?.ToList();
+            if (localUris != null && localUris.Any())
+            {
+                if(uri.Scheme.ToLowerInvariant() != "bolt+routing")
+                    throw new NotSupportedException($"To use the {nameof(BoltGraphClient)} you need to provide a 'bolt://' scheme, not '{uri.Scheme}'.");
 
+                addressResolver = new AddressResolver(uri, localUris);
+            }
+            else if (uri.Scheme.ToLowerInvariant() != "bolt" && uri.Scheme.ToLowerInvariant() != "bolt+routing")
+                throw new NotSupportedException($"To use the {nameof(BoltGraphClient)} you need to provide a 'bolt://' or 'bolt+routing://' scheme, not '{uri.Scheme}'.");
+
+            
             this.uri = uri;
             this.username = username;
             this.password = password;

--- a/Neo4jClient.Shared/AddressResolver.cs
+++ b/Neo4jClient.Shared/AddressResolver.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Neo4j.Driver.V1;
+
+namespace Neo4jClient
+{
+    internal class AddressResolver : IServerAddressResolver
+    {
+        private readonly Dictionary<ServerAddress, List<ServerAddress>> servers = new Dictionary<ServerAddress, List<ServerAddress>>();
+
+        public AddressResolver()
+            :this(null, new string[0])
+        { }
+
+        public AddressResolver(string virtualUri, IEnumerable<string> uris)
+        :this(UriCreator.From(virtualUri), uris?.Select(UriCreator.From))
+        {}
+
+        public AddressResolver(Uri virtualUri, IEnumerable<Uri> uris)
+        {
+            servers.Add(ServerAddress.From(virtualUri), uris == null
+                ? new List<ServerAddress>()
+                : new List<ServerAddress>(uris.Select(ServerAddress.From)));
+        }
+
+        public ISet<ServerAddress> Resolve(ServerAddress address)
+        {
+            if(address == null && servers.Keys.Count > 1)
+                throw new InvalidOperationException("Unable to resolve addresses to use as no virtual uri passed in.");
+            
+            var localServers = address == null || !servers.ContainsKey(address) ? servers.First().Value : servers[address];
+            return new HashSet<ServerAddress>(localServers);
+        }
+    }
+}

--- a/Neo4jClient.Shared/DriverWrapper.cs
+++ b/Neo4jClient.Shared/DriverWrapper.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Neo4j.Driver.V1;
+
+namespace Neo4jClient
+{
+    /*
+     *
+     private IDriver CreateDriverWithCustomResolver(string virtualUri, IAuthToken token,
+    params ServerAddress[] addresses)
+{
+    return GraphDatabase.Driver(virtualUri, token,
+        new Config {Resolver = new ListAddressResolver(addresses), EncryptionLevel = EncryptionLevel.None});
+}
+
+public void AddPerson(string name)
+{
+    using (var driver = CreateDriverWithCustomResolver("bolt+routing://x.acme.com",
+        AuthTokens.Basic(Username, Password),
+        ServerAddress.From("a.acme.com", 7687), ServerAddress.From("b.acme.com", 7877),
+        ServerAddress.From("c.acme.com", 9092)))
+    {
+        using (var session = driver.Session())
+        {
+            session.Run("CREATE (a:Person {name: $name})", new {name});
+        }
+    }
+}
+
+private class ListAddressResolver : IServerAddressResolver
+{
+    private readonly ServerAddress[] servers;
+
+    public ListAddressResolver(params ServerAddress[] servers)
+    {
+        this.servers = servers;
+    }
+
+    public ISet<ServerAddress> Resolve(ServerAddress address)
+    {
+        return new HashSet<ServerAddress>(servers);
+    }
+}
+     *
+     */
+
+    internal class DriverWrapper : IDriver
+    {
+        private readonly IDriver driver;
+        public string Username { get;  }
+        public string Password { get; }
+        public string Realm { get; }
+
+        public DriverWrapper(IDriver driver)
+        {
+            this.driver = driver;
+        }
+
+        public DriverWrapper(string uri, IServerAddressResolver addressResolver, string username, string pass, string realm)
+            :this(new Uri(uri), addressResolver, username, pass, realm)
+        {
+        }
+
+        public DriverWrapper(Uri uri, IServerAddressResolver addressResolver, string username, string pass, string realm)
+        {
+            Uri = uri;
+            Username = username;
+            Password = pass;
+            Realm = realm;
+
+            var authToken = GetAuthToken(username, pass, realm);
+            this.driver = addressResolver == null
+                ? GraphDatabase.Driver(uri, authToken) 
+                : GraphDatabase.Driver(uri, authToken, new Config { Resolver = addressResolver });
+        }
+        
+        public ISession Session()
+        {
+            return driver.Session();
+        }
+
+        public ISession Session(AccessMode defaultMode)
+        {
+            return driver.Session(defaultMode);
+        }
+
+        public ISession Session(string bookmark)
+        {
+            return driver.Session(bookmark);
+        }
+
+        public ISession Session(AccessMode defaultMode, string bookmark)
+        {
+            return driver.Session(defaultMode, bookmark);
+        }
+
+        public ISession Session(AccessMode defaultMode, IEnumerable<string> bookmarks)
+        {
+            return driver.Session(defaultMode, bookmarks);
+        }
+
+        public ISession Session(IEnumerable<string> bookmarks)
+        {
+            return driver.Session(bookmarks);
+        }
+
+        public void Close()
+        {
+            driver.Close();
+        }
+
+        public Task CloseAsync()
+        {
+            return driver.CloseAsync();
+        }
+
+        public Uri Uri { get; }
+
+        public IServerAddressResolver AddressResolver { get; }
+
+        private static IAuthToken GetAuthToken(string username, string password, string realm)
+        {
+            return string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password)
+                ? AuthTokens.None
+                : AuthTokens.Basic(username, password, realm);
+        }
+        public void Dispose()
+        {
+            driver?.Dispose();
+        }
+    }
+}

--- a/Neo4jClient.Shared/Neo4jClient.Shared.projitems
+++ b/Neo4jClient.Shared/Neo4jClient.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Neo4jClient</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AddressResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AggregateExceptionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AmbiguousRelationshipDirectionException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\BatchResponse.cs" />
@@ -74,6 +75,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\VbComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeleteMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DetachedNodeException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DriverWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Execution\BatchExecutionPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Execution\CypherExecutionPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Execution\CypherTransactionExecutionPolicy.cs" />
@@ -207,6 +209,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Transactions\ITransactionManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transactions\ITransactionResourceManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transactions\TransactionHttpUtils.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UriCreator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Neo4jClient.Shared/UriCreator.cs
+++ b/Neo4jClient.Shared/UriCreator.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Neo4jClient
+{
+    internal static class UriCreator
+    {
+        /// <summary>
+        /// Creates a <see cref="Uri"/> from the given <see cref="string"/> <paramref name="uri"/> instance.
+        /// </summary>
+        /// <param name="uri">A <see cref="string"/> representing a URI, can contain the scheme, or not.</param>
+        /// <returns>A <see cref="Uri"/> from the given <see cref="string"/> <paramref name="uri"/> instance.</returns>
+        public static Uri From(string uri)
+        {
+            if (string.IsNullOrWhiteSpace(uri))
+                return null;
+
+            if (uri.IndexOf("://", StringComparison.Ordinal) == -1)
+                uri = $"scheme://{uri}";
+
+            var output = new UriBuilder(uri);
+            if (output.Uri.IsDefaultPort)
+                output.Port = 7687;
+
+            return output.Uri;
+        }
+    }
+}

--- a/Neo4jClient.Tests.Shared/AddressResolverTests.cs
+++ b/Neo4jClient.Tests.Shared/AddressResolverTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Neo4j.Driver.V1;
+using Neo4jClient.Test.Fixtures;
+using Xunit;
+
+namespace Neo4jClient.Tests.Shared
+{
+    public class AddressResolverTests : IClassFixture<CultureInfoSetupFixture>
+    {
+        [Fact]
+        public void CreatesEmptyListIfNullIsPassedIn()
+        {
+            var ar = new AddressResolver(new Uri("bolt://virtual.uri:1234"), null);
+            var response = ar.Resolve(ServerAddress.From("virtual.uri", 1234));
+            response.Should().HaveCount(0);
+        }
+
+        [Fact]
+        public void PassesBackCorrectUris()
+        {
+            const string uri1 = "x.acme.com";
+            const string uri2 = "y.acme.com";
+
+            var ar = new AddressResolver("bolt://virtual.uri", new []{$"bolt://{uri1}", "bolt://" + uri2});
+            var response = ar.Resolve(null).ToList();
+            response.Should().HaveCount(2);
+            response.Any(x => x.Host == uri1).Should().BeTrue();
+            response.Any(x => x.Host == uri2).Should().BeTrue();
+        }
+    }
+
+    public class UriCreatorTests : IClassFixture<CultureInfoSetupFixture>
+    {
+        [Theory]
+        [InlineData("x.foo.com", "scheme://x.foo.com:7687/", 7687)]
+        [InlineData("x.foo.com:7687", "scheme://x.foo.com:7687/", 7687)]
+        [InlineData("x.foo.com:7688", "scheme://x.foo.com:7688/", 7688)]
+        [InlineData("bolt://x.foo.com:7688", "bolt://x.foo.com:7688/", 7688)]
+        public void GeneratesTheCorrectUri(string input, string expectedUri, int expectedPort)
+        {
+            var response = UriCreator.From(input);
+            response.AbsoluteUri.Should().Be(expectedUri);
+            response.Port.Should().Be(expectedPort);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void ReturnsNullWhenNullOrWhitespacePassedIn(string uri)
+        {
+            UriCreator.From(uri).Should().BeNull();
+        }
+    }
+}

--- a/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
+++ b/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Neo4jClient.Tests.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AddressResolverTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\GremlinTableCapResponseTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\RootApiResponseTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiUsageIdeas.cs" />

--- a/Neo4jClient/BoltGraphClient.cs
+++ b/Neo4jClient/BoltGraphClient.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
-using Neo4jClient.Cypher;
+using Neo4j.Driver.V1;
 using Neo4jClient.Execution;
 using Neo4jClient.Transactions;
 using Newtonsoft.Json;
@@ -13,10 +14,34 @@ namespace Neo4jClient
 {
     public partial class BoltGraphClient : IBoltGraphClient, IRawGraphClient, ITransactionalGraphClient
     {
-        public BoltGraphClient(Uri uri, string username = null, string password = null, string realm = null)
+        /// <summary>
+        ///     Creates a new instance of the <see cref="BoltGraphClient" />.
+        /// </summary>
+        /// <param name="uri">
+        ///     If the <paramref name="uris" /> parameter is provided, this will be treated as a <em>virtual URI</em>
+        ///     , else it will be the URI connected to.
+        /// </param>
+        /// <param name="uris">
+        ///     A collection of <see cref="Uri" /> instances to connect to using an
+        ///     <see cref="IServerAddressResolver" />. Leave <c>null</c> (or empty) if you don't want to use it.
+        /// </param>
+        /// <param name="username">The username to connect to Neo4j with.</param>
+        /// <param name="password">The password to connect to Neo4j with.</param>
+        /// <param name="realm">The realm to connect to Neo4j with.</param>
+        public BoltGraphClient(Uri uri, IEnumerable<Uri> uris, string username = null, string password = null, string realm = null)
         {
-            if ((uri.Scheme == "http") || (uri.Scheme == "https"))
-                throw new NotSupportedException($"To use the {nameof(BoltGraphClient)} you need to provide a 'bolt://' scheme, not '{uri.Scheme}'.");
+            var localUris = uris?.ToList();
+            if (localUris != null && localUris.Any())
+            {
+                if (uri.Scheme.ToLowerInvariant() != "bolt+routing")
+                    throw new NotSupportedException($"To use the {nameof(BoltGraphClient)} you need to provide a 'bolt://' scheme, not '{uri.Scheme}'.");
+
+                addressResolver = new AddressResolver(uri, localUris);
+            }
+            else if (uri.Scheme.ToLowerInvariant() != "bolt" && uri.Scheme.ToLowerInvariant() != "bolt+routing")
+            {
+                throw new NotSupportedException($"To use the {nameof(BoltGraphClient)} you need to provide a 'bolt://' or 'bolt+routing://' scheme, not '{uri.Scheme}'.");
+            }
 
             this.uri = uri;
             this.username = username;


### PR DESCRIPTION
In a cluster situation, we could only pass a single URI which meant that should the URI not be contactable, even though other machines in the cluster were, you couldn't connect to it.

With the `Neo4j-Driver` 1.7 release, we could pass in multiple bolt addresses to the Driver to give guides as to where to connect should the main URI be uncontactable. This PR brings that functionality to the `Neo4jClient`.

**This is only for Bolt connections** 

First off, if you're not connecting to a cluster - then don't worry - no code changes!
If you _are_ and you have a rotating DNS type thing set up - then dont worry - no code changes!

If you _do_ want to use it though - there are 2 options available to you:

1. Provide a virtual URI

```
var client = new BoltGraphClient("bolt+routing://virtual.uri", new []{"x.foo.com:7687", "y.foo.com" , "z.foo.com:7688" }, "neo4j", "neo");
```

If you don't supply a port, the default of `7687` will be used. If you provide one, of course, that will be used. The virtual uri is something that you don't really need to worry about - hence the overload...

2. Don't provide a virtual URI

```
var client = new BoltGraphClient(new []{"x.foo.com:7687", "y.foo.com" , "z.foo.com:7688" }, "neo4j", "neo");
```

In this case, `Neo4jClient` will use `bolt+routing://virtual.neo4j.uri` as the virtual URI under the hood.