### PR TITLE
Serialize to Neo4j DateTime instances with Attribute (#327)

### DIFF
--- a/Neo4jClient.Shared/Attributes/Neo4jDateTimeAttribute.cs
+++ b/Neo4jClient.Shared/Attributes/Neo4jDateTimeAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Neo4jClient
+{
+    /// <summary>
+    /// If this is used on a <see cref="System.DateTime"/> property - it will be serialized as a Neo4j Date object rather than a string
+    /// </summary>
+    public class Neo4jDateTimeAttribute : Attribute
+    {
+    }
+}

--- a/Neo4jClient.Shared/BoltGraphClient.cs
+++ b/Neo4jClient.Shared/BoltGraphClient.cs
@@ -33,7 +33,9 @@ namespace Neo4jClient
             new TypeConverterBasedJsonConverter(),
             new NullableEnumValueConverter(),
             new TimeZoneInfoConverter(),
-            new EnumValueConverter()
+            new EnumValueConverter(),
+            new ZonedDateTimeConverter(), 
+            new LocalDateTimeConverter()
         };
 
         private static readonly DefaultContractResolver DefaultJsonContractResolver = new DefaultContractResolver();
@@ -558,7 +560,20 @@ namespace Neo4jClient
             }
             else
             {
-                var converted = result.Select(record => record.Deserialize(deserializer, query.ResultMode));
+
+                StatementResultHelper.JsonSettings = new JsonSerializerSettings
+                {
+                    Converters = JsonConverters,
+                    ContractResolver = JsonContractResolver
+                };
+
+                List<IEnumerable<TResult>> converted = new List<IEnumerable<TResult>>();
+                foreach (var record in result)
+                {
+                    var des = record.Deserialize(deserializer, query.ResultMode);
+                    converted.Add(des);
+                }
+
                 foreach (var enumerable in converted)
                 {
                     results.AddRange(enumerable);

--- a/Neo4jClient.Shared/Neo4jClient.Shared.projitems
+++ b/Neo4jClient.Shared/Neo4jClient.Shared.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\RelationshipApiResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\RelationshipTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiModels\RootApiResponse.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Attributes\Neo4jDateTimeAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BoltGraphClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CypherPartialResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Cypher\All.cs" />
@@ -199,6 +200,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TimeZoneInfoConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TypeConverterBasedJsonConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TypeMapping.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\ZonedDateTimeConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StatementResultHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transactions\BoltResponse.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transactions\IInternalTransactionalGraphClient.cs" />

--- a/Neo4jClient.Shared/Neo4jDriverExtensions.cs
+++ b/Neo4jClient.Shared/Neo4jDriverExtensions.cs
@@ -40,7 +40,7 @@ namespace Neo4jClient
             public object Value { get; set; }
         }
 
-        private static object Serialize(object value, IList<JsonConverter> converters, IGraphClient gc)
+        private static object Serialize(object value, IList<JsonConverter> converters, IGraphClient gc, IEnumerable<CustomAttributeData> customAttributes = null)
         {
             if (value == null)
             {
@@ -55,6 +55,11 @@ namespace Neo4jClient
             {
                 var serializer = new CustomJsonSerializer{JsonConverters = converters, JsonContractResolver = ((IRawGraphClient)gc).JsonContractResolver};
                 return JsonConvert.DeserializeObject<CustomJsonConverterHelper>(serializer.Serialize(new {value})).Value;
+            }
+
+            if (customAttributes != null && customAttributes.Any(x => x.AttributeType == typeof(Neo4jDateTimeAttribute)))
+            {
+                return value;
             }
 
             if (typeInfo.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
@@ -79,7 +84,7 @@ namespace Neo4jClient
         {
             return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
                 .Where(pi => !(pi.GetIndexParameters().Any() || pi.IsDefined(typeof(JsonIgnoreAttribute))))
-                .ToDictionary(pi => pi.Name, pi => Serialize(pi.GetValue(value), converters, gc));
+                .ToDictionary(pi => pi.Name, pi => Serialize(pi.GetValue(value), converters, gc, pi.CustomAttributes));
         }
         
         private static object SerializeCollection(IEnumerable value, IList<JsonConverter> converters, IGraphClient gc)

--- a/Neo4jClient.Shared/Serialization/ZonedDateTimeConverter.cs
+++ b/Neo4jClient.Shared/Serialization/ZonedDateTimeConverter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using Neo4j.Driver.V1;
+using Newtonsoft.Json;
+
+namespace Neo4jClient.Serialization
+{
+    public class ZonedDateTimeConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var zdt = (ZonedDateTime)value;
+            zdt.As<DateTimeOffset>();
+
+            var typeConverter = TypeDescriptor.GetConverter(zdt.GetType());
+            writer.WriteValue(typeConverter.ConvertToInvariantString(value));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null) return null;
+            var typeConverter = TypeDescriptor.GetConverter(typeof(DateTimeOffset));
+            var dto = (DateTimeOffset) typeConverter.ConvertFromString(reader.Value.ToString());
+            return new ZonedDateTime(dto);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(ZonedDateTime) == objectType;
+        }
+    }
+
+
+    public class LocalDateTimeConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var ldt = (LocalDateTime)value;
+            ldt.As<DateTime>();
+
+            var typeConverter = TypeDescriptor.GetConverter(ldt.GetType());
+            writer.WriteValue(typeConverter.ConvertToInvariantString(value));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null) return null;
+            var typeConverter = TypeDescriptor.GetConverter(typeof(DateTime));
+            var dt = typeConverter.ConvertFromString(reader.Value.ToString()) as DateTime?;
+            return new LocalDateTime(dt ?? DateTime.MinValue);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(LocalDateTime) == objectType;
+        }
+    }
+}

--- a/Neo4jClient.Shared/StatementResultHelper.cs
+++ b/Neo4jClient.Shared/StatementResultHelper.cs
@@ -16,11 +16,17 @@ namespace Neo4jClient
 {
     internal static class StatementResultHelper
     {
+        internal static JsonSerializerSettings JsonSettings { get; set; } =
+            new JsonSerializerSettings
+            {
+                Converters = BoltGraphClient.DefaultJsonConverters.Reverse().ToList()
+            };
+
         internal static string ToJsonString(this INode node, bool inSet = false, bool isNested = false, bool isNestedInList = false)
         {
             var props = node
                 .Properties
-                .Select(p => $"\"{p.Key}\":{JsonConvert.SerializeObject(p.Value)}");
+                .Select(p => $"\"{p.Key}\":{JsonConvert.SerializeObject(p.Value, JsonSettings)}");
 
             if (isNestedInList)
             {
@@ -41,7 +47,7 @@ namespace Neo4jClient
         {
             var props = relationship
                 .Properties
-                .Select(p => $"\"{p.Key}\":{JsonConvert.SerializeObject(p.Value)}");
+                .Select(p => $"\"{p.Key}\":{JsonConvert.SerializeObject(p.Value, JsonSettings)}");
 
             if (isNestedInList)
             {

--- a/Neo4jClient.Tests.Shared/BoltGraphClientTests/BoltGraphClientTests.cs
+++ b/Neo4jClient.Tests.Shared/BoltGraphClientTests/BoltGraphClientTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using Neo4j.Driver.V1;
 using Neo4jClient.Test.BoltGraphClientTests;
 using Neo4jClient.Test.Fixtures;
+using Neo4jClient.Tests.Shared;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -91,9 +92,7 @@ namespace Neo4jClient.Test.Extensions
         {
             var mockSession = new Mock<ISession>();
             mockSession.Setup(s => s.Run("CALL dbms.components()")).Returns(new ServerInfo());
-
             
-
             var mockDriver = new Mock<IDriver>();
             mockDriver.Setup(d => d.Session(It.IsAny<AccessMode>())).Returns(mockSession.Object);
             mockDriver.Setup(d => d.Session(It.IsAny<AccessMode>(), It.IsAny<IEnumerable<string>>())).Returns(mockSession.Object);
@@ -114,7 +113,7 @@ namespace Neo4jClient.Test.Extensions
             };
 
             var query = cfq.Query;
-            CompareDictionaries(query.ToNeo4jDriverParameters(bgc), expectedParameters).Should().BeTrue();
+            query.ToNeo4jDriverParameters(bgc).IsEqualTo(expectedParameters).Should().BeTrue();
         }
 
         [Fact]
@@ -143,7 +142,7 @@ namespace Neo4jClient.Test.Extensions
             };
 
             var query = cfq.Query;
-            CompareDictionaries(query.ToNeo4jDriverParameters(bgc), expectedParameters).Should().BeTrue();
+            query.ToNeo4jDriverParameters(bgc).IsEqualTo(expectedParameters).Should().BeTrue();
         }
 
         [Fact]
@@ -170,7 +169,7 @@ namespace Neo4jClient.Test.Extensions
             }};
 
             var query = cfq.Query;
-            CompareDictionaries(query.ToNeo4jDriverParameters(bgc), expectedParameters).Should().BeTrue();
+            query.ToNeo4jDriverParameters(bgc).IsEqualTo(expectedParameters).Should().BeTrue();
         }
 
         [Fact]
@@ -194,33 +193,7 @@ namespace Neo4jClient.Test.Extensions
             var expectedParameters = new Dictionary<string, object> {{"p0", $"{cwg.Id}"}};
 
             var query = cfq.Query;
-            CompareDictionaries(query.ToNeo4jDriverParameters(bgc), expectedParameters).Should().BeTrue();
-        }
-
-        private static bool CompareDictionaries<TKey, TValue>(IDictionary<TKey, TValue> d1, IDictionary<TKey, TValue> d2)
-        {
-            if (d1 == null && d2 == null)
-                return true;
-            if (d1 == null || d2 == null)
-                return false;
-
-            if (d1.Count != d2.Count)
-                return false;
-
-            foreach (var d1Key in d1.Keys)
-            {
-                if (!d2.ContainsKey(d1Key))
-                    return false;
-
-                var v1 = d1[d1Key];
-                var v2 = d2[d1Key];
-                if (v1.GetType() == typeof(Dictionary<TKey, TValue>))
-                    return CompareDictionaries((IDictionary<TKey, TValue>)v1, (IDictionary<TKey, TValue>)v2);
-
-                if (!d1[d1Key].Equals(d2[d1Key]))
-                    return false;
-            }
-            return true;
+            query.ToNeo4jDriverParameters(bgc).IsEqualTo(expectedParameters).Should().BeTrue();
         }
 
         [Fact]

--- a/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
+++ b/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
@@ -131,9 +131,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\CustomJsonDeserializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\CustomJsonSerializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\CypherJsonDeserializerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\SerializesDateTimeAsNeoDateTimeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\UserSuppliedSerializationTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StatementResultHelperTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestsImplementFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UtilitiesTests.cs" />
   </ItemGroup>
 </Project>

--- a/Neo4jClient.Tests.Shared/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
+++ b/Neo4jClient.Tests.Shared/Serialization/SerializesDateTimeAsNeoDateTimeTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Moq;
+using Neo4j.Driver.V1;
+using Neo4jClient.Test.Extensions;
+using Neo4jClient.Test.Fixtures;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Neo4jClient.Tests.Shared.Serialization
+{
+    public class SerializesDateTimeAsNeoDateTimeTests : IClassFixture<CultureInfoSetupFixture>
+    {
+        private class ClassWithNeo4jDateTime
+        {
+            [Neo4jDateTime]
+            public DateTime Dt { get; set; }
+        }
+
+        [Fact]
+        public void SerializesDateTimeAsNeoDateInBolt()
+        {
+            var mockSession = new Mock<ISession>();
+            mockSession.Setup(s => s.Run("CALL dbms.components()")).Returns(new BoltGraphClientTests.ServerInfo());
+            var dt = new DateTime(2000, 1, 1, 0, 0, 0);
+
+            var mockDriver = new Mock<IDriver>();
+            mockDriver.Setup(d => d.Session(It.IsAny<AccessMode>())).Returns(mockSession.Object);
+            mockDriver.Setup(d => d.Session(It.IsAny<AccessMode>(), It.IsAny<IEnumerable<string>>())).Returns(mockSession.Object);
+            mockDriver.Setup(d => d.Uri).Returns(new Uri("bolt://localhost"));
+
+            var bgc = new BoltGraphClient(mockDriver.Object);
+            bgc.Connect();
+
+            var cwd = new ClassWithNeo4jDateTime { Dt = dt }; ;
+
+            var cfq = bgc.Cypher.Create("(c)").WithParam("testParam", cwd);
+
+            var expectedParameters = new Dictionary<string, object>
+            {
+                {
+                    "testParam", new Dictionary<string, object> {{"Dt", dt}}
+                }
+            };
+
+            var query = cfq.Query;
+            var parameters = query.ToNeo4jDriverParameters(bgc);
+            parameters.IsEqualTo(expectedParameters).Should().BeTrue();
+        }
+
+    }
+}

--- a/Neo4jClient.Tests.Shared/StatementResultHelperTests.cs
+++ b/Neo4jClient.Tests.Shared/StatementResultHelperTests.cs
@@ -93,6 +93,12 @@ namespace Neo4jClient.Test
             public DateTimeOffset Offset { get; set; }
         }
 
+        private class ClassWithDateTimeAndAttribute
+        {
+            [Neo4jDateTime]
+            public DateTimeOffset Offset { get; set; }
+        }
+
         private class ClassWithArray
         {
             public string[] StrArr { get; set; }
@@ -409,6 +415,22 @@ namespace Neo4jClient.Test
                 var result = record.Parse<ClassWithArray>(GraphClient);
                 result.Should().NotBeNull();
                 result.StrArr.Should().HaveCount(2);
+            }
+
+            [Fact]
+            public void ParsesDateTimesFromNeo4jCorrectly()
+            {
+                LocalDateTime ldt = new LocalDateTime(2000,3,1,1,1,1);
+                var node = new TestNode(new Dictionary<string, object> { { "Offset", ldt } });
+                var record = Substitute.For<IRecord>();
+                record.Keys.Returns(new List<string> { "X" });
+                record["X"].Returns(node);
+
+                var result = record.Parse<ClassWithDateTimeAndAttribute>(GraphClient);
+                result.Should().NotBeNull();
+                result.Offset.Year.Should().Be(2000);
+                result.Offset.Month.Should().Be(3);
+                result.Offset.Day.Should().Be(1);
             }
 
             [Fact]

--- a/Neo4jClient.Tests.Shared/TestUtilities.cs
+++ b/Neo4jClient.Tests.Shared/TestUtilities.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+
+namespace Neo4jClient.Tests.Shared
+{
+    public static class TestUtilities
+    {
+        public static bool IsEqualTo<TKey, TValue>(this IDictionary<TKey, TValue> d1, IDictionary<TKey, TValue> d2)
+        {
+            if (d1 == null && d2 == null)
+                return true;
+            if (d1 == null || d2 == null)
+                return false;
+
+            if (d1.Count != d2.Count)
+                return false;
+
+            foreach (var d1Key in d1.Keys)
+            {
+                if (!d2.ContainsKey(d1Key))
+                    return false;
+
+                var v1 = d1[d1Key];
+                var v2 = d2[d1Key];
+                if (v1.GetType() == typeof(Dictionary<TKey, TValue>))
+                    return IsEqualTo((IDictionary<TKey, TValue>)v1, (IDictionary<TKey, TValue>)v2);
+
+                if (!d1[d1Key].Equals(d2[d1Key]))
+                    return false;
+            }
+            return true;
+        }
+    }
+}

--- a/Neo4jClient/BoltGraphClient.cs
+++ b/Neo4jClient/BoltGraphClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Neo4j.Driver.V1;
 using Neo4jClient.Execution;
+using Neo4jClient.Serialization;
 using Neo4jClient.Transactions;
 using Newtonsoft.Json;
 


### PR DESCRIPTION
Adding [Neo4jDateTime] to a DateTime/DateTimeOffset will store in Neo4j as a DateTime object instead of a string