### PR TITLE
Adding `In` and `NotIn` as extension methods for Object

### DIFF
--- a/Neo4jClient.Shared/Cypher/CypherWhereExpressionVisitor.cs
+++ b/Neo4jClient.Shared/Cypher/CypherWhereExpressionVisitor.cs
@@ -41,6 +41,8 @@ namespace Neo4jClient.Cypher
                 { "StartsWith",  VisitStartsWithMethod },
                 { "Contains",  VisitContainsMethod },
                 { "EndsWith",  VisitEndsWithMethod },
+                { "In", VisitInMethod },
+                { "NotIn", VisitNotInMethod }
             };
         }
 
@@ -53,6 +55,28 @@ namespace Neo4jClient.Cypher
             }
 
             return base.VisitMethodCall(node);
+        }
+
+        private Expression VisitInMethod(MethodCallExpression node)
+        {
+            TextOutput.Append("(");
+            Visit(node.Arguments[0]);
+            TextOutput.Append(" IN ");
+            Visit(node.Arguments[1]);
+            TextOutput.Append(")");
+
+            return node;
+        }
+
+        private Expression VisitNotInMethod(MethodCallExpression node)
+        {
+            TextOutput.Append("NOT (");
+            Visit(node.Arguments[0]);
+            TextOutput.Append(" IN ");
+            Visit(node.Arguments[1]);
+            TextOutput.Append(")");
+
+            return node;
         }
 
         private Expression VisitStartsWithMethod(MethodCallExpression node)

--- a/Neo4jClient.Shared/Extensions/ObjectExtensions.cs
+++ b/Neo4jClient.Shared/Extensions/ObjectExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Neo4jClient.Extensions
+{
+    public static class ObjectExtensions
+    {
+
+        public static bool In<T>(this T obj, IEnumerable<T> enumerable)
+        {
+            return enumerable.Contains(obj);
+        }
+
+        public static bool NotIn<T>(this T obj, IEnumerable<T> enumerable)
+        {
+            return !obj.In(enumerable);
+        }
+    }
+}

--- a/Neo4jClient.Shared/Neo4jClient.Shared.projitems
+++ b/Neo4jClient.Shared/Neo4jClient.Shared.projitems
@@ -107,6 +107,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Execution\RestExecutionPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\EnumerableExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\MemberInfoExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\ObjectExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GraphClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GraphClientExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GraphClientFactory.cs" />

--- a/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWhereTests.cs
+++ b/Neo4jClient.Tests.Shared/Cypher/CypherFluentQueryWhereTests.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Serialization;
 using NSubstitute;
 using Xunit;
 using Neo4jClient.Cypher;
+using Neo4jClient.Extensions;
 using Neo4jClient.Test.Fixtures;
 using Newtonsoft.Json;
 
@@ -44,6 +45,31 @@ namespace Neo4jClient.Test.Cypher
         // ReSharper restore ClassNeverInstantiated.Local
         // ReSharper restore UnusedAutoPropertyAccessor.Local
 
+        [Fact]
+        public void CreatesNotInQuery()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            client.CypherCapabilities.Returns(CypherCapabilities.Cypher19);
+            var arr = new[] { 1, 2, 3, 4 };
+            var query = new CypherFluentQuery(client).Where((Foo foo) => foo.Bar.NotIn(arr)).Query;
+
+            Assert.Equal("WHERE NOT (foo.Bar IN {p0})", query.QueryText);
+            Assert.Equal(1, query.QueryParameters.Count);
+            Assert.Equal(arr, query.QueryParameters["p0"]);
+        }
+
+        [Fact]
+        public void CreatesInQuery()
+        {
+            var client = Substitute.For<IRawGraphClient>();
+            client.CypherCapabilities.Returns(CypherCapabilities.Cypher19);
+            var arr = new[] {1, 2, 3, 4};
+            var query = new CypherFluentQuery(client).Where((Foo foo) => foo.Bar.In(arr)).Query;
+
+            Assert.Equal("WHERE (foo.Bar IN {p0})", query.QueryText);
+            Assert.Equal(1, query.QueryParameters.Count);
+            Assert.Equal(arr, query.QueryParameters["p0"]);
+        }
 
         [Fact]
         public void CreatesStartWithQuery()

--- a/Neo4jClient.Tests.Shared/Extensions/ObjectExtensionTests.cs
+++ b/Neo4jClient.Tests.Shared/Extensions/ObjectExtensionTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Neo4jClient.Extensions;
+using Neo4jClient.Test.Fixtures;
+using Xunit;
+
+namespace Neo4jClient.Test.Extensions
+{
+    public class ObjectExtensionTests
+    {
+        public class InMethod : IClassFixture<CultureInfoSetupFixture>
+        {
+            [Fact]
+            public void ReturnsTrue_WhenItemIsInList()
+            {
+                var list = new List<int> {1, 2, 3, 4};
+                2.In(list).Should().BeTrue();
+            }
+
+            [Fact]
+            public void ReturnsFalse_WhenItemNotInList()
+            {
+                var list = new List<int> { 1, 2, 3, 4 };
+                5.In(list).Should().BeFalse();
+            }
+        }
+
+        public class NotInMethod : IClassFixture<CultureInfoSetupFixture>
+        {
+            [Fact]
+            public void ReturnsTrue_WhenItemIsNotInList()
+            {
+                var list = new List<int> { 1, 2, 3, 4 };
+                5.NotIn(list).Should().BeTrue();
+            }
+
+            [Fact]
+            public void ReturnsTrue_WhenItemIsNotInList2()
+            {
+                5.NotIn(new [] {1,2,3,4}).Should().BeTrue();
+            }
+
+            [Fact]
+            public void ReturnsFalse_WhenItemInList()
+            {
+                var list = new List<int> { 1, 2, 3, 4 };
+                4.NotIn(list).Should().BeFalse();
+            }
+        }
+    }
+}

--- a/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
+++ b/Neo4jClient.Tests.Shared/Neo4jClient.Tests.Shared.projitems
@@ -64,6 +64,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\MemberInfoExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\Neo4jDriverExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BoltGraphClientTests\BoltGraphClientTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\ObjectExtensionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GraphClientTests\ConnectAsyncTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GraphClientTests\ConnectTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GraphClientTests\CreateIndexTests.cs" />


### PR DESCRIPTION
You can now do: 
```
var years = new [] {1980, 1982, 1984};
/*.. stuff ..*/
.Where((Person p) => p.Born.In(years))
```

Which will generate:
`WHERE (p.Born IN {p0})`